### PR TITLE
Add spiral galaxy generation

### DIFF
--- a/scenes/galaxy.tscn
+++ b/scenes/galaxy.tscn
@@ -11,6 +11,7 @@
 script = ExtResource("2_mlxib")
 scene_to_instance = ExtResource("1_jxn3g")
 radius = 100.0
+star_count = 200
 
 [node name="Camera2D" type="Camera2D" parent="."]
 zoom = Vector2(2.48, 2.48)

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -1,12 +1,33 @@
 extends Node2D
 
+## Scene that will be instanced for each generated star.
 @export var scene_to_instance: PackedScene
-@export var count: int = 8
+## Total number of stars to create.
+@export var star_count: int = 100
+## Maximum radius of the galaxy.
 @export var radius: float = 200.0
+## How many arms the spiral galaxy has.
+@export var arm_count: int = 2
+## Total twist of the spiral from the center to the outer edge.
+@export var twist: float = TAU * 2
+## Random angle deviation for each star.
+@export var arm_spread: float = 0.3
+## Random radial offset for each star.
+@export var random_offset: float = 10.0
 
 func _ready():
-	for i in range(count):
-		var instance = scene_to_instance.instantiate()
-		var angle = TAU * i / count
-		instance.position = Vector2(cos(angle), sin(angle)) * radius
-		add_child(instance)
+        generate_spiral_galaxy()
+
+## Generates a simple spiral galaxy. Adjust exported variables to
+## tweak the resulting shape.
+func generate_spiral_galaxy() -> void:
+        randomize()
+        for i in range(star_count):
+                var instance = scene_to_instance.instantiate()
+                var t := float(i) / star_count
+                var arm := randi() % arm_count
+                var r := t * radius + randf_range(-random_offset, random_offset)
+                var angle := t * twist + TAU * arm / arm_count
+                angle += randf_range(-arm_spread, arm_spread)
+                instance.position = Vector2(cos(angle), sin(angle)) * r
+                add_child(instance)


### PR DESCRIPTION
## Summary
- enhance `world_generation.gd` to produce a spiral galaxy
- configure `galaxy.tscn` to generate more stars

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684cb32d771c832395e7fb1c195aa5b8