### PR TITLE
Add camera movement and zoom controls

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -14,3 +14,11 @@ config/name="Hegswam"
 run/main_scene="uid://bey6hgn2q5xdd"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+
+[input]
+camera_move_up={"deadzone":0.5,"events":[{"type":"key","keycode":87}]}
+camera_move_down={"deadzone":0.5,"events":[{"type":"key","keycode":83}]}
+camera_move_left={"deadzone":0.5,"events":[{"type":"key","keycode":65}]}
+camera_move_right={"deadzone":0.5,"events":[{"type":"key","keycode":68}]}
+camera_zoom_in={"deadzone":0.5,"events":[{"type":"key","keycode":81}]}
+camera_zoom_out={"deadzone":0.5,"events":[{"type":"key","keycode":69}]}

--- a/scenes/galaxy.tscn
+++ b/scenes/galaxy.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://bey6hgn2q5xdd"]
+[gd_scene load_steps=4 format=3 uid="uid://bey6hgn2q5xdd"]
 
 [ext_resource type="PackedScene" uid="uid://cwj81lysn86dj" path="res://assets/star.tscn" id="1_jxn3g"]
 [ext_resource type="Script" uid="uid://dmtkapt354yxv" path="res://scripts/world_generation.gd" id="2_mlxib"]
+[ext_resource type="Script" uid="uid://np57nlm1t5vo" path="res://scripts/camera_controller.gd" id="3_invlcp"]
 
 [node name="Node2D" type="Node2D"]
 
@@ -14,4 +15,5 @@ radius = 100.0
 star_count = 200
 
 [node name="Camera2D" type="Camera2D" parent="."]
+script = ExtResource("3_invlcp")
 zoom = Vector2(2.48, 2.48)

--- a/scripts/camera_controller.gd
+++ b/scripts/camera_controller.gd
@@ -1,0 +1,35 @@
+extends Camera2D
+
+## Camera movement speed in pixels per second.
+@export var move_speed: float = 200.0
+## How quickly the zoom level changes when zooming in or out.
+@export var zoom_speed: float = 1.0
+## Minimum allowed zoom level.
+@export var max_zoom_in: float = 0.5
+## Maximum allowed zoom level.
+@export var max_zoom_out: float = 4.0
+
+func _process(delta: float) -> void:
+    var direction := Vector2.ZERO
+    if Input.is_action_pressed("camera_move_up"):
+        direction.y -= 1
+    if Input.is_action_pressed("camera_move_down"):
+        direction.y += 1
+    if Input.is_action_pressed("camera_move_left"):
+        direction.x -= 1
+    if Input.is_action_pressed("camera_move_right"):
+        direction.x += 1
+    if direction != Vector2.ZERO:
+        position += direction.normalized() * move_speed * delta
+
+    var zoom_change := 0.0
+    if Input.is_action_pressed("camera_zoom_in"):
+        zoom_change -= zoom_speed * delta
+    if Input.is_action_pressed("camera_zoom_out"):
+        zoom_change += zoom_speed * delta
+    if zoom_change != 0.0:
+        _update_zoom(zoom_change)
+
+func _update_zoom(delta_z: float) -> void:
+    var new_zoom := clamp(zoom.x + delta_z, max_zoom_in, max_zoom_out)
+    zoom = Vector2(new_zoom, new_zoom)

--- a/scripts/camera_controller.gd.uid
+++ b/scripts/camera_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://np57nlm1t5vo


### PR DESCRIPTION
## Summary
- add `camera_controller.gd` for WASD camera movement and zoom control
- register camera input mappings in `project.godot`
- hook the camera controller script into the `galaxy` scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb64c95908323aeedf72b2410e13a