### PR TITLE
Add seeded galaxy generation

### DIFF
--- a/assets/star.tscn
+++ b/assets/star.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://cwj81lysn86dj"]
+[gd_scene load_steps=3 format=3 uid="uid://cwj81lysn86dj"]
+
+[ext_resource type="Script" path="res://scripts/star.gd" id="1"]
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_gyjrx"]
 
 [node name="star" type="Node2D"]
+script = ExtResource("1")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2.38419e-07, 2.38419e-07)

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+## Unique seed for this star, useful for deterministic system generation.
+@export var seed: int = 0

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -14,20 +14,25 @@ extends Node2D
 @export var arm_spread: float = 0.3
 ## Random radial offset for each star.
 @export var random_offset: float = 10.0
+## Seed used to deterministically generate the galaxy.
+@export var seed: int = 0
+
+var rng := RandomNumberGenerator.new()
 
 func _ready():
-		generate_spiral_galaxy()
+                rng.seed = seed
+                generate_spiral_galaxy()
 
 ## Generates a simple spiral galaxy. Adjust exported variables to
 ## tweak the resulting shape.
 func generate_spiral_galaxy() -> void:
-		randomize()
-		for i in range(star_count):
-				var instance = scene_to_instance.instantiate()
-				var t := float(i) / star_count
-				var arm := randi() % arm_count
-				var r := t * radius + randf_range(-random_offset, random_offset)
-				var angle := t * twist + TAU * arm / arm_count
-				angle += randf_range(-arm_spread, arm_spread)
-				instance.position = Vector2(cos(angle), sin(angle)) * r
-				add_child(instance)
+                for i in range(star_count):
+                                var instance = scene_to_instance.instantiate()
+                                var t := float(i) / star_count
+                                var arm := rng.randi() % arm_count
+                                var r := t * radius + rng.randf_range(-random_offset, random_offset)
+                                var angle := t * twist + TAU * arm / arm_count
+                                angle += rng.randf_range(-arm_spread, arm_spread)
+                                instance.position = Vector2(cos(angle), sin(angle)) * r
+                                instance.seed = rng.randi()
+                                add_child(instance)


### PR DESCRIPTION
## Summary
- add script for stars that exposes a `seed` property
- seed galaxy generation so the same seed generates identical stars
- assign each star a unique seed when spawned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dafaf9f948323be26e639fdec97c0