### PR TITLE
Add clickable stars and basic star system scene

### DIFF
--- a/scenes/starSystem.tscn
+++ b/scenes/starSystem.tscn
@@ -1,3 +1,8 @@
 [gd_scene format=3 uid="uid://g1us8g0k07it"]
 
+[ext_resource type="PackedScene" uid="uid://b4rey3dsg2s6k" path="res://assets/sun.tscn" id="1"]
+[ext_resource type="Script" uid="uid://zqu1h6go4tqf9" path="res://scripts/star_system.gd" id="2"]
+
 [node name="StarSystem" type="Node2D"]
+script = ExtResource("2")
+sun_scene = ExtResource("1")

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -2,3 +2,14 @@ extends Node2D
 
 ## Unique seed for this star, useful for deterministic system generation.
 @export var seed: int = 0
+
+## Called when the node is ready. Sets up input handling so the star can be
+## clicked by the player.
+func _on_ready() -> void:
+    input_pickable = true
+
+## Handles mouse input on the star. When the player left-clicks the star, the
+## scene changes to the star system view.
+func _input_event(viewport, event: InputEvent, _shape_idx: int) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        get_tree().change_scene_to_file("res://scenes/starSystem.tscn")

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -1,0 +1,9 @@
+extends Node2D
+
+## Scene used for the system's star.
+@export var sun_scene: PackedScene = preload("res://assets/sun.tscn")
+
+func _ready() -> void:
+    var sun: Node2D = sun_scene.instantiate()
+    add_child(sun)
+    sun.position = Vector2.ZERO

--- a/scripts/star_system.gd.uid
+++ b/scripts/star_system.gd.uid
@@ -1,0 +1,1 @@
+uid://zqu1h6go4tqf9


### PR DESCRIPTION
## Summary
- let stars accept mouse input
- change to StarSystem scene when clicked
- spawn a Sun when entering a star system

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684db2f470d4832389bc3e0e6fb05647