### PR TITLE
Fix star click handler

### DIFF
--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -4,14 +4,16 @@ extends Node2D
 @export var seed: int = 0
 
 ## Called when the node is ready. Sets up input handling so the star can be
-## clicked by the player. The ``input_pickable`` property needs to be set on
-## this ``Node2D`` rather than the ``Sprite2D`` child in order for ``_input_event``
-## to be triggered.
+## clicked by the player. In Godot 4 the ``input_pickable`` property must be
+## enabled on the ``Sprite2D`` child so that its ``input_event`` signal emits
+## when clicked.
 func _on_ready() -> void:
-    input_pickable = true
+    var sprite: Sprite2D = $Sprite2D
+    sprite.input_pickable = true
+    sprite.connect("input_event", _on_sprite_input_event)
 
 ## Handles mouse input on the star. When the player left-clicks the star, the
 ## scene changes to the star system view.
-func _input_event(viewport, event: InputEvent, _shape_idx: int) -> void:
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		get_tree().change_scene_to_file("res://scenes/starSystem.tscn")
+func _on_sprite_input_event(viewport: Viewport, event: InputEvent, _shape_idx: int) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        get_tree().change_scene_to_file("res://scenes/starSystem.tscn")


### PR DESCRIPTION
## Summary
- handle star click on Sprite2D instead of Node2D

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684db6d1aa888323953b644df115500c