### PR TITLE
Add planet generation in star systems

### DIFF
--- a/assets/planet.tscn
+++ b/assets/planet.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://planet"]
+
+[sub_resource type="CanvasTexture" id="CanvasTexture_planet"]
+
+[node name="Planet" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(0, 0)
+scale = Vector2(2, -2)
+texture = SubResource("CanvasTexture_planet")

--- a/project.godot
+++ b/project.godot
@@ -65,3 +65,6 @@ camera_zoom_out={
 }, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+
+[autoload]
+Globals="*res://scripts/globals.gd"

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -1,0 +1,3 @@
+extends Node
+
+var star_seed: int = 0

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -7,6 +7,7 @@ extends Node2D
 ## scene changes to the star system view.
 func _on_sprite_input_event(viewport: Viewport, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		Globals.star_seed = seed
 		get_tree().change_scene_to_file("res://scenes/star_system.tscn")
 
 

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -2,8 +2,29 @@ extends Node2D
 
 ## Scene used for the system's star.
 @export var sun_scene: PackedScene = preload("res://assets/sun.tscn")
+## Scene used for planets orbiting the star.
+@export var planet_scene: PackedScene = preload("res://assets/planet.tscn")
+## Minimum number of planets to generate.
+@export var min_planets: int = 1
+## Maximum number of planets to generate.
+@export var max_planets: int = 5
+## Spacing between each planet's orbit.
+@export var orbit_step: float = 40.0
+
+var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
 func _ready() -> void:
+	rng.seed = Globals.star_seed
 	var sun: Node2D = sun_scene.instantiate()
 	add_child(sun)
 	sun.position = Vector2.ZERO
+	_generate_planets(sun)
+
+func _generate_planets(sun: Node2D) -> void:
+	var count := rng.randi_range(min_planets, max_planets)
+		for i in range(count):
+		var planet: Node2D = planet_scene.instantiate()
+		add_child(planet)
+		var radius := orbit_step * (i + 1) + rng.randf_range(-orbit_step * 0.25, orbit_step * 0.25)
+		var angle := rng.randf_range(0.0, TAU)
+		planet.position = sun.position + Vector2(cos(angle), sin(angle)) * radius


### PR DESCRIPTION
## Summary
- add a minimal planet scene
- add Globals singleton to share data between scenes
- store selected star seed on click
- generate planets around the sun using that seed
- configure project to autoload Globals

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684dbe686c50832389bb730896d225e9