### PR TITLE
Add back navigation from star system view

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -65,6 +65,14 @@ camera_zoom_out={
 }, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":5,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+return_to_galaxy={
+"deadzone": 0.5,
+"events": [{
+"keycode": 16777217,
+"type": "key"
+}, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":16777217,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [autoload]
 Globals="*res://scripts/globals.gd"

--- a/scenes/star_system.tscn
+++ b/scenes/star_system.tscn
@@ -11,8 +11,26 @@ orbit_step = 140.0
 
 [node name="MainCamera" parent="." instance=ExtResource("2_be1mv")]
 
-[node name="BackButton" type="Button" parent="."]
-text = "Back"
-position = Vector2(10.0, 10.0)
+[node name="UI" type="CanvasLayer" parent="."]
 
-[connection signal="pressed" from="BackButton" to="." method="_on_back_button_pressed"]
+[node name="BottomPanel" type="Panel" parent="UI"]
+anchor_right = 1.0
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_right = 0.0
+offset_top = -60.0
+offset_bottom = 0.0
+
+[node name="BackButton" type="Button" parent="UI/BottomPanel"]
+text = "Back to Galaxy"
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_top = 0.0
+anchor_bottom = 1.0
+offset_left = -60.0
+offset_right = 60.0
+offset_top = 10.0
+offset_bottom = -10.0
+
+[connection signal="pressed" from="UI/BottomPanel/BackButton" to="." method="_on_back_button_pressed"]

--- a/scenes/star_system.tscn
+++ b/scenes/star_system.tscn
@@ -10,3 +10,9 @@ max_planets = 8
 orbit_step = 140.0
 
 [node name="MainCamera" parent="." instance=ExtResource("2_be1mv")]
+
+[node name="BackButton" type="Button" parent="."]
+text = "Back"
+position = Vector2(10.0, 10.0)
+
+[connection signal="pressed" from="BackButton" to="." method="_on_back_button_pressed"]

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -28,3 +28,10 @@ func _generate_planets(sun: Node2D) -> void:
 		var radius := orbit_step * (i + 1) + rng.randf_range(-orbit_step * 0.25, orbit_step * 0.25)
 		var angle := rng.randf_range(0.0, TAU)
 		planet.position = sun.position + Vector2(cos(angle), sin(angle)) * radius
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("return_to_galaxy"):
+		get_tree().change_scene_to_file("res://scenes/galaxy.tscn")
+
+func _on_back_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/galaxy.tscn")


### PR DESCRIPTION
## Summary
- allow exiting the star system view
- show a button to return to the galaxy
- add `return_to_galaxy` input action

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684dcc3c7d388323958a41cbf116f8af