### PR TITLE
Restrict drone to initial system

### DIFF
--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -1,5 +1,8 @@
 extends Node
 
 var star_seed: int = 0
+## Seed of the first star system visited. Used to determine where the
+## player's drone should appear.
+var start_star_seed: int = 0
 ## Indicates whether the galaxy scene has been opened for the first time.
 var first_load: bool = true

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -43,10 +43,12 @@ func _spawn_planets(sun: Node2D) -> void:
 		planets.append(planet)
 
 func _spawn_drone() -> void:
-	if drone_scene == null or planets.is_empty():
-		return
-	drone = drone_scene.instantiate()
-	add_child(drone)
+       if drone_scene == null or planets.is_empty():
+               return
+       if Globals.star_seed != Globals.start_star_seed:
+               return
+       drone = drone_scene.instantiate()
+       add_child(drone)
 	var planet: Node2D = planets[rng.randi_range(0, planets.size() - 1)]
 	drone.position = planet.position + Vector2(20, 0)
 	drone_target = drone.position

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -63,7 +63,8 @@ func _open_random_star_system() -> void:
 	var stars := get_children()
 	if stars.size() == 0:
 		return
-	var star_index := rng.randi_range(0, stars.size() - 1)
-	var star := stars[star_index]
-	Globals.star_seed = star.seed
-	get_tree().change_scene_to_file("res://scenes/star_system.tscn")
+       var star_index := rng.randi_range(0, stars.size() - 1)
+       var star := stars[star_index]
+       Globals.star_seed = star.seed
+       Globals.start_star_seed = star.seed
+       get_tree().change_scene_to_file("res://scenes/star_system.tscn")


### PR DESCRIPTION
## Summary
- track the player's starting star system
- spawn the drone only if the current system matches the starting system
- store the starting system when opening the initial star

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684ddf047f6083238f84938de573e0bd