### PR TITLE
Implement galaxy drone travel

### DIFF
--- a/assets/galaxy_drone.tscn
+++ b/assets/galaxy_drone.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/galaxy_drone.gd" id="1"]
+
+[sub_resource type="CanvasTexture" id="CanvasTexture_planet"]
+
+[node name="GalaxyDrone" type="Node2D"]
+scale = Vector2(8, 7.88)
+script = ExtResource("1")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(1.96826, -0.642853)
+texture = SubResource("CanvasTexture_planet")

--- a/scenes/galaxy.tscn
+++ b/scenes/galaxy.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://bey6hgn2q5xdd"]
+[gd_scene load_steps=5 format=3 uid="uid://bey6hgn2q5xdd"]
 
 [ext_resource type="PackedScene" uid="uid://cwj81lysn86dj" path="res://assets/star.tscn" id="1_jxn3g"]
 [ext_resource type="Script" uid="uid://dmtkapt354yxv" path="res://scripts/world_generation.gd" id="2_mlxib"]
 [ext_resource type="PackedScene" uid="uid://bn0wywribwxc6" path="res://assets/main_camera.tscn" id="3_mlxib"]
+[ext_resource type="PackedScene" path="res://assets/galaxy_drone.tscn" id="4_drone"]
 
 [node name="Node2D" type="Node2D"]
 
@@ -11,6 +12,7 @@
 [node name="script" type="Node2D" parent="World"]
 script = ExtResource("2_mlxib")
 scene_to_instance = ExtResource("1_jxn3g")
+drone_scene = ExtResource("4_drone")
 star_count = 420
 radius = 600.0
 twist = 6.0

--- a/scripts/galaxy_drone.gd
+++ b/scripts/galaxy_drone.gd
@@ -1,0 +1,21 @@
+extends Node2D
+
+@export var move_speed: float = 80.0
+@export var enter_distance: float = 40.0
+
+var target_position: Vector2
+
+func _ready() -> void:
+	add_to_group("galaxy_drone")
+	target_position = position
+
+func move_to(pos: Vector2) -> void:
+	target_position = pos
+
+func is_near(pos: Vector2) -> bool:
+	return position.distance_to(pos) <= enter_distance
+
+func _process(delta: float) -> void:
+	var delta_pos := target_position - position
+	if delta_pos.length() > 1.0:
+		position += delta_pos.normalized() * move_speed * delta

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -17,17 +17,20 @@ func _ready() -> void:
 ## Handles mouse input on the star. When the player left-clicks the star, the
 ## scene changes to the star system view.
 func _on_star_clicked() -> void:
-	Globals.star_seed = seed
-	get_tree().change_scene_to_file('res://scenes/star_system.tscn')
+       var drone = get_tree().get_first_node_in_group("galaxy_drone")
+       if drone and drone.has_method("is_near") and drone.call("is_near", global_position):
+               Globals.star_seed = seed
+               get_tree().change_scene_to_file('res://scenes/star_system.tscn')
+       elif drone and drone.has_method("move_to"):
+               drone.call("move_to", global_position)
 
 func _on_sprite_input_event(viewport: Viewport, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		_on_star_clicked()
 
 func _on_area_2d_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		_on_star_clicked()
-		print(event)
+       if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+               _on_star_clicked()
 
 
 func _on_area_2d_mouse_entered() -> void:

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -4,6 +4,8 @@ const GalaxyGenerator = preload("res://scripts/generators/galaxy_generator.gd")
 
 ## Scene instantiated for each generated star.
 @export var scene_to_instance: PackedScene
+## Scene used for the drone in the galaxy view.
+@export var drone_scene: PackedScene
 ## Total number of stars to create.
 @export var star_count: int = 100
 ## Maximum radius of the galaxy.
@@ -21,14 +23,16 @@ const GalaxyGenerator = preload("res://scripts/generators/galaxy_generator.gd")
 
 var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 var generator: GalaxyGenerator = GalaxyGenerator.new()
+var drone: Node2D
 
 func _ready() -> void:
-	rng.seed = seed
-	_generate_galaxy()
-	_highlight_last_visited()
-	if Globals.first_load:
-		Globals.first_load = false
-		_open_random_star_system()
+        rng.seed = seed
+        _generate_galaxy()
+        _highlight_last_visited()
+       _spawn_drone()
+        if Globals.first_load:
+                Globals.first_load = false
+                _open_random_star_system()
 
 ## Generates a simple spiral galaxy. Adjust exported variables to tweak the
 ## resulting shape.
@@ -53,11 +57,21 @@ func _generate_galaxy() -> void:
 		add_child(instance)
 
 func _highlight_last_visited() -> void:
-	for star in get_children():
-		if "seed" in star and star.seed == Globals.star_seed:
-			if star.has_method("mark_as_last_visited"):
-				star.mark_as_last_visited()
-				break
+        for star in get_children():
+                if "seed" in star and star.seed == Globals.star_seed:
+                        if star.has_method("mark_as_last_visited"):
+                                star.mark_as_last_visited()
+                                break
+
+func _spawn_drone() -> void:
+       if drone_scene == null:
+               return
+       for star in get_children():
+               if "seed" in star and star.seed == Globals.start_star_seed:
+                       drone = drone_scene.instantiate()
+                       add_child(drone)
+                       drone.position = star.position + Vector2(20, 0)
+                       break
 
 func _open_random_star_system() -> void:
 	var stars := get_children()


### PR DESCRIPTION
## Summary
- add `galaxy_drone.tscn` and matching `galaxy_drone.gd` for the galaxy map
- spawn the galaxy drone in `world_generation.gd`
- only allow entering stars when the drone is nearby
- move the drone toward a clicked star if it is far away

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de36729ec8323a5e986befc08a59d