### PR TITLE
Add orbit display for planets

### DIFF
--- a/scripts/orbit_drawer.gd
+++ b/scripts/orbit_drawer.gd
@@ -1,0 +1,11 @@
+class_name OrbitDrawer
+extends Node2D
+
+@export var radius: float = 100.0
+@export var color: Color = Color(1, 1, 1, 0.5)
+
+func _ready():
+update()
+
+func _draw():
+draw_arc(Vector2.ZERO, radius, 0, TAU, 64, color, 1.0)

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -10,3 +10,6 @@ func _ready():
 		var angle = TAU * i / count
 		instance.position = Vector2(cos(angle), sin(angle)) * radius
 		add_child(instance)
+		var orbit = OrbitDrawer.new()
+		orbit.radius = radius
+		add_child(orbit)


### PR DESCRIPTION
## Summary
- add `OrbitDrawer` script that draws circular arcs
- draw an orbit ring for each instantiated planet in `world_generation.gd`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850670b84d48323b89f3b8727eda4f8