### PR TITLE
Implement star-centered asteroid belt

### DIFF
--- a/assets/asteroid.tscn
+++ b/assets/asteroid.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3 uid="uid://6rurf2kawqfh"]
+
+[sub_resource type="CanvasTexture" id="CanvasTexture_gyjrx"]
+
+[node name="star" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(2.38419e-07, 2.38419e-07)
+scale = Vector2(3, 3)
+texture = SubResource("CanvasTexture_gyjrx")
+offset = Vector2(-2.98023e-08, 0)

--- a/scenes/galaxy.tscn
+++ b/scenes/galaxy.tscn
@@ -1,16 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://bey6hgn2q5xdd"]
+[gd_scene load_steps=4 format=3 uid="uid://bey6hgn2q5xdd"]
 
 [ext_resource type="PackedScene" uid="uid://cwj81lysn86dj" path="res://assets/star.tscn" id="1_jxn3g"]
 [ext_resource type="Script" uid="uid://dmtkapt354yxv" path="res://scripts/world_generation.gd" id="2_mlxib"]
+[ext_resource type="PackedScene" uid="uid://6rurf2kawqfh" path="res://assets/asteroid.tscn" id="3_ast"]
+
 
 [node name="Node2D" type="Node2D"]
+[node name="Sun" parent="." instance=ExtResource("1_jxn3g")]
 
 [node name="WorldGeneration" type="Node2D" parent="."]
 
 [node name="script" type="Node2D" parent="WorldGeneration"]
 script = ExtResource("2_mlxib")
-scene_to_instance = ExtResource("1_jxn3g")
-radius = 100.0
+scene_to_instance = ExtResource("3_ast")
+distance_to_sun = 100.0
 
 [node name="Camera2D" type="Camera2D" parent="."]
 zoom = Vector2(2.48, 2.48)

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -2,11 +2,11 @@ extends Node2D
 
 @export var scene_to_instance: PackedScene
 @export var count: int = 8
-@export var radius: float = 200.0
+@export var distance_to_sun: float = 200.0
 
 func _ready():
 	for i in range(count):
 		var instance = scene_to_instance.instantiate()
 		var angle = TAU * i / count
-		instance.position = Vector2(cos(angle), sin(angle)) * radius
+                instance.position = Vector2(cos(angle), sin(angle)) * distance_to_sun
 		add_child(instance)


### PR DESCRIPTION
## Summary
- add new asteroid scene
- introduce `distance_to_sun` variable for belt radius
- center a Sun in the galaxy scene and spawn asteroids around it

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685069a0187c832399d4a223610e8c81