### PR TITLE
Fix drone starting motion on galaxy load

### DIFF
--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -72,6 +72,7 @@ func _spawn_drone() -> void:
                        drone = drone_scene.instantiate()
                        add_child(drone)
                        drone.position = star.position + Vector2(20, 0)
+                       drone.set("target_position", drone.position)
                        break
 
 func _center_camera_on_last_visited() -> void:


### PR DESCRIPTION
## Summary
- stop the galaxy drone from automatically flying to `(0,0)` when the galaxy scene loads

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6850943eb9b48323ba1463f64f97871c