### PR TITLE
Make belt and planets clickable

### DIFF
--- a/assets/planet.tscn
+++ b/assets/planet.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://be4xg8et6uoia"]
+[gd_scene load_steps=3 format=3 uid="uid://be4xg8et6uoia"]
+
+[ext_resource type="Script" path="res://scripts/planet.gd" id="1"]
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_planet"]
 
 [node name="Planet" type="Node2D"]
+script = ExtResource("1")
 scale = Vector2(8, 7.88)
 
 [node name="Sprite2D" type="Sprite2D" parent="."]

--- a/scripts/asteroid_belt.gd
+++ b/scripts/asteroid_belt.gd
@@ -1,13 +1,45 @@
 extends Node2D
 
-@export var radius: float = 100.0
+var _radius: float = 100.0
+@export var radius: float = 100.0:
+    set = set_radius,
+    get = get_radius
+@export var thickness: float = 20.0
 @export var dot_count: int = 40
 @export var dot_radius: float = 2.0
 @export var color: Color = Color.LIGHT_GRAY
 
+var _points: PackedVector2Array = []
+var _rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
-func _draw() -> void:
+func _ready() -> void:
+    _generate_points()
+
+func set_radius(value: float) -> void:
+    _radius = value
+    _generate_points()
+
+func get_radius() -> float:
+    return _radius
+
+func _generate_points() -> void:
+    _points.clear()
+    _rng.randomize()
     for i in range(dot_count):
         var angle := TAU * float(i) / dot_count
-        var pos := Vector2(cos(angle), sin(angle)) * radius
+        var dist := radius + _rng.randf_range(-thickness / 2.0, thickness / 2.0)
+        var pos := Vector2(cos(angle), sin(angle)) * dist
+        _points.append(pos)
+    update()
+
+
+func _draw() -> void:
+    for pos in _points:
         draw_circle(pos, dot_radius, color)
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        var local_pos := to_local(event.position)
+        var dist := local_pos.length()
+        if dist >= radius - thickness / 2.0 and dist <= radius + thickness / 2.0:
+            print("belt clicked")

--- a/scripts/planet.gd
+++ b/scripts/planet.gd
@@ -1,0 +1,8 @@
+extends Node2D
+
+@export var click_radius: float = 16.0
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        if global_position.distance_to(event.position) <= click_radius:
+            print("planet clicked")


### PR DESCRIPTION
## Summary
- add exported planet script to emit click message
- give asteroid belt thickness and click detection

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509413e814832397f5506f52728aa1