### PR TITLE
Enable spacebar toggle between galaxy and star system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -77,6 +77,14 @@ return_to_galaxy={
 }, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":16777217,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+toggle_star_system={
+"deadzone": 0.5,
+"events": [{
+"keycode": 32,
+"type": "key"
+}, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -74,7 +74,7 @@ func _process(delta: float) -> void:
             drone.position = drone_target
 
 func _unhandled_input(event: InputEvent) -> void:
-    if event.is_action_pressed('return_to_galaxy'):
+    if event.is_action_pressed('return_to_galaxy') or event.is_action_pressed('toggle_star_system'):
         get_tree().change_scene_to_file('res://scenes/galaxy.tscn')
     elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
         drone_target = get_global_mouse_position()

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -96,3 +96,10 @@ func _open_random_star_system() -> void:
     Globals.star_seed = star.seed
     Globals.start_star_seed = star.seed
     get_tree().change_scene_to_file("res://scenes/star_system.tscn")
+
+func _open_last_star_system() -> void:
+    get_tree().change_scene_to_file("res://scenes/star_system.tscn")
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event.is_action_pressed('toggle_star_system'):
+        _open_last_star_system()


### PR DESCRIPTION
## Summary
- map `toggle_star_system` action to the space key
- allow spacebar to exit a star system back to the galaxy
- handle spacebar in the galaxy scene to reopen the last visited star system

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850948abdb08323bdcdbcb081603a7a