### PR TITLE
Fix planet/belt click detection with zoom

### DIFF
--- a/scripts/asteroid_belt.gd
+++ b/scripts/asteroid_belt.gd
@@ -38,7 +38,7 @@ func _draw() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-        var local_pos := to_local(event.position)
+        var local_pos := to_local(get_global_mouse_position())
         var dist := local_pos.length()
         if dist >= radius - thickness / 2.0 and dist <= radius + thickness / 2.0:
             print("belt clicked")

--- a/scripts/planet.gd
+++ b/scripts/planet.gd
@@ -4,5 +4,5 @@ extends Node2D
 
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-        if global_position.distance_to(event.position) <= click_radius:
+        if global_position.distance_to(get_global_mouse_position()) <= click_radius:
             print("planet clicked")


### PR DESCRIPTION
## Summary
- use world mouse coordinates when checking for planet or belt clicks

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6850971f903883238efe6428f83baf59