### PR TITLE
Add space scene and asteroid belt thickness

### DIFF
--- a/assets/space_asteroid.tscn
+++ b/assets/space_asteroid.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/asteroid.gd" id="1"]
+
+[node name="SpaceAsteroid" type="Node2D"]
+script = ExtResource("1")

--- a/scenes/space.tscn
+++ b/scenes/space.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/space.gd" id="1"]
+[ext_resource type="PackedScene" path="res://assets/main_camera.tscn" id="2"]
+
+[node name="Space" type="Node2D"]
+script = ExtResource("1")
+
+[node name="MainCamera" parent="." instance=ExtResource("2")]

--- a/scripts/asteroid.gd
+++ b/scripts/asteroid.gd
@@ -1,11 +1,14 @@
 extends Node2D
 
+signal clicked(global_position: Vector2)
+
 @export var radius: float = 2.0
 @export var click_radius: float = 4.0
 @export var color: Color = Color.WHITE
 
 func _ready() -> void:
     update()
+    add_to_group("asteroid")
 
 func _draw() -> void:
     draw_circle(Vector2.ZERO, radius, color)
@@ -13,4 +16,4 @@ func _draw() -> void:
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
         if global_position.distance_to(get_global_mouse_position()) <= click_radius:
-            print("asteroid clicked")
+            emit_signal("clicked", global_position)

--- a/scripts/asteroid_belt.gd
+++ b/scripts/asteroid_belt.gd
@@ -6,6 +6,7 @@ var _radius: float = 100.0
     get = get_radius
 @export var asteroid_count: int = 20
 @export var asteroid_scene: PackedScene = preload("res://assets/asteroid.tscn")
+@export var thickness: float = 20.0
 
 var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
@@ -27,6 +28,7 @@ func _generate_asteroids() -> void:
         var asteroid: Node2D = asteroid_scene.instantiate()
         add_child(asteroid)
         var angle := rng.randf() * TAU
-        asteroid.position = Vector2(cos(angle), sin(angle)) * radius
+        var r := radius + rng.randf_range(-thickness / 2.0, thickness / 2.0)
+        asteroid.position = Vector2(cos(angle), sin(angle)) * r
 
 

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -10,3 +10,7 @@ var first_load: bool = true
 const STAR_SYSTEM_SCENE_PATH := "res://scenes/star_system.tscn"
 ## Number of drones that should spawn in the next opened star system.
 var entering_drone_count: int = 0
+## Positions of asteroids passed to the space scene.
+var space_asteroid_positions: Array = []
+## Path to the space scene file.
+const SPACE_SCENE_PATH := "res://scenes/space.tscn"

--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -1,0 +1,11 @@
+extends Node2D
+
+@export var asteroid_scene: PackedScene = preload("res://assets/space_asteroid.tscn")
+
+func _ready() -> void:
+    var positions := Globals.space_asteroid_positions
+    for pos in positions:
+        var asteroid: Node2D = asteroid_scene.instantiate()
+        add_child(asteroid)
+        asteroid.position = pos
+    Globals.space_asteroid_positions = []

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -26,6 +26,7 @@ var drones: Array = []
 var drone_targets: Array = []
 ## Speed at which the drone moves toward the target position.
 @export var drone_speed: float = 80.0
+var asteroid_click_radius: float = 10.0
 
 func _ready() -> void:
     rng.seed = Globals.star_seed
@@ -33,6 +34,7 @@ func _ready() -> void:
     add_child(sun)
     sun.position = Vector2.ZERO
     _spawn_planets(sun)
+    _connect_asteroids()
     _spawn_drones()
 
 func _spawn_planets(sun: Node2D) -> void:
@@ -63,6 +65,19 @@ func _spawn_drones() -> void:
         drones.append(d)
         drone_targets.append(d.position)
     Globals.entering_drone_count = 0
+
+func _connect_asteroids() -> void:
+    for asteroid in get_tree().get_nodes_in_group("asteroid"):
+        if asteroid.has_signal("clicked"):
+            asteroid.connect("clicked", Callable(self, "_on_asteroid_clicked"))
+
+func _on_asteroid_clicked(click_pos: Vector2) -> void:
+    var positions: Array = []
+    for asteroid in get_tree().get_nodes_in_group("asteroid"):
+        if asteroid.global_position.distance_to(click_pos) <= asteroid_click_radius:
+            positions.append(asteroid.global_position - click_pos)
+    Globals.space_asteroid_positions = positions
+    get_tree().change_scene_to_file(Globals.SPACE_SCENE_PATH)
 
 func _process(delta: float) -> void:
     for i in range(drones.size()):


### PR DESCRIPTION
## Summary
- add a thickness property to asteroid belts
- allow asteroids to emit a `clicked` signal
- connect asteroid clicks in the star system to open the new Space scene
- store selected asteroid positions in Globals and spawn them in the Space scene
- add new Space scene and SpaceAsteroid asset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851c45f72e08323a03061a8d4c352cd