### PR TITLE
Fix asteroid click events

### DIFF
--- a/scripts/asteroid_belt.gd
+++ b/scripts/asteroid_belt.gd
@@ -27,6 +27,7 @@ func _generate_asteroids() -> void:
     for i in range(asteroid_count):
         var asteroid: Node2D = asteroid_scene.instantiate()
         add_child(asteroid)
+        asteroid.add_to_group("asteroid")
         var angle := rng.randf() * TAU
         var r := radius + rng.randf_range(-thickness / 2.0, thickness / 2.0)
         asteroid.position = Vector2(cos(angle), sin(angle)) * r


### PR DESCRIPTION
## Summary
- add asteroids to the `asteroid` group when generating asteroid belts so their click signals connect in star systems

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851cbf549708323b2f2591c035220b5