### PR TITLE
Add procedural star visuals

### DIFF
--- a/assets/sun.tscn
+++ b/assets/sun.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=2 format=3 uid="uid://b4rey3dsg2s6k"]
+[gd_scene load_steps=3 format=3 uid="uid://b4rey3dsg2s6k"]
+
+[ext_resource type="Script" path="res://scripts/sun.gd" id="1"]
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_e1m50"]
 
 [node name="Sun" type="Node2D"]
+script = ExtResource("1")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2.38419e-07, 2.38419e-07)

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -10,9 +10,31 @@ extends Node2D
 
 var _default_color: Color
 var _is_last_visited: bool = false
+var _glow_sprite: Sprite2D
+
+func _generate_color() -> Color:
+    return StarVisuals.color_from_seed(seed)
+
+func _create_glow(color: Color) -> void:
+    _glow_sprite = Sprite2D.new()
+    _glow_sprite.texture = $Sprite2D.texture
+    _glow_sprite.scale = $Sprite2D.scale * 2.0
+    var mat := CanvasItemMaterial.new()
+    mat.blend_mode = CanvasItemMaterial.BLEND_MODE_ADD
+    _glow_sprite.material = mat
+    _glow_sprite.modulate = color
+    _glow_sprite.z_index = -1
+    add_child(_glow_sprite)
+
+func _set_star_color(color: Color) -> void:
+    $Sprite2D.modulate = color
+    if _glow_sprite:
+        _glow_sprite.modulate = color
 
 func _ready() -> void:
-    _default_color = $Sprite2D.modulate
+    _default_color = _generate_color()
+    _set_star_color(_default_color)
+    _create_glow(_default_color)
 
 ## Handles mouse input on the star. When the player left-clicks the star, the
 ## scene changes to the star system view.
@@ -52,15 +74,15 @@ func _on_area_2d_input_event(viewport: Node, event: InputEvent, shape_idx: int) 
 
 
 func _on_area_2d_mouse_entered() -> void:
-    $Sprite2D.modulate = hover_color
+    _set_star_color(hover_color)
 
 func _on_area_2d_mouse_exited() -> void:
     if _is_last_visited:
-        $Sprite2D.modulate = visited_color
+        _set_star_color(visited_color)
     else:
-        $Sprite2D.modulate = _default_color
+        _set_star_color(_default_color)
 
 ## Marks this star as the last visited and updates its visual highlight.
 func mark_as_last_visited() -> void:
     _is_last_visited = true
-    $Sprite2D.modulate = visited_color
+    _set_star_color(visited_color)

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -36,7 +36,11 @@ var asteroid_click_radius: float = 200.0
 func _ready() -> void:
     rng.seed = Globals.star_seed
     sun = sun_scene.instantiate()
+    if "seed" in sun:
+        sun.seed = Globals.star_seed
     add_child(sun)
+    if sun.has_method("_generate_visuals"):
+        sun._generate_visuals(Globals.star_seed)
     sun.position = Vector2.ZERO
     _spawn_planets(sun)
     _connect_asteroids()

--- a/scripts/star_visuals.gd
+++ b/scripts/star_visuals.gd
@@ -1,0 +1,10 @@
+extends Object
+class_name StarVisuals
+
+static func color_from_seed(seed: int) -> Color:
+    var rng := RandomNumberGenerator.new()
+    rng.seed = seed
+    var hue := rng.randf()
+    var sat := 0.6 + rng.randf() * 0.4
+    var val := 0.8 + rng.randf() * 0.2
+    return Color.from_hsv(hue, sat, val)

--- a/scripts/sun.gd
+++ b/scripts/sun.gd
@@ -1,0 +1,25 @@
+extends Node2D
+
+@export var seed: int = 0
+
+var _glow_sprite: Sprite2D
+
+func _ready() -> void:
+    _generate_visuals(seed)
+
+func _generate_visuals(seed_value: int) -> void:
+    seed = seed_value
+    var color := StarVisuals.color_from_seed(seed)
+    $Sprite2D.modulate = color
+    _create_glow(color)
+
+func _create_glow(color: Color) -> void:
+    _glow_sprite = Sprite2D.new()
+    _glow_sprite.texture = $Sprite2D.texture
+    _glow_sprite.scale = $Sprite2D.scale * 3.0
+    var mat := CanvasItemMaterial.new()
+    mat.blend_mode = CanvasItemMaterial.BLEND_MODE_ADD
+    _glow_sprite.material = mat
+    _glow_sprite.modulate = color
+    _glow_sprite.z_index = -1
+    add_child(_glow_sprite)


### PR DESCRIPTION
## Summary
- generate star colors deterministically with new `StarVisuals` helper
- add glow effects to stars in the galaxy
- create a new `Sun` script for system stars
- hook up sun visuals based on the system seed

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f718c14483239d0193f3b03ff83d