### PR TITLE
Maintain system drone positions

### DIFF
--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -16,5 +16,9 @@ var space_asteroid_positions: Array = []
 var space_drone_positions: Array = []
 ## Position where the galaxy drone should reappear when returning from a star system.
 var galaxy_drone_position: Vector2 = Vector2.ZERO
+## Star-system coordinates of the asteroid clicked to open the space scene.
+var space_origin: Vector2 = Vector2.ZERO
+## Absolute positions of drones to restore when returning from the space scene.
+var system_drone_positions: Array = []
 ## Path to the space scene file.
 const SPACE_SCENE_PATH := "res://scenes/space.tscn"

--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -27,9 +27,11 @@ func _ready() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed('toggle_star_system'):
+        _save_system_drone_positions()
         get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
 
 func _on_back_button_pressed() -> void:
+    _save_system_drone_positions()
     get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
 
 func _on_asteroid_mined(global_pos: Vector2) -> void:
@@ -39,3 +41,9 @@ func _on_asteroid_mined(global_pos: Vector2) -> void:
     add_child(iron)
     iron.global_position = global_pos
     iron.scale *= 10
+
+func _save_system_drone_positions() -> void:
+    var positions: Array = []
+    for d in get_tree().get_nodes_in_group("drone"):
+        positions.append(Globals.space_origin + d.position / 10)
+    Globals.system_drone_positions = positions

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -63,6 +63,18 @@ func _spawn_planets(sun: Node2D) -> void:
 func _spawn_drones() -> void:
     if drone_scene == null or planets.is_empty():
         return
+
+    if Globals.system_drone_positions.size() > 0:
+        for pos in Globals.system_drone_positions:
+            var d: Node2D = drone_scene.instantiate()
+            add_child(d)
+            d.position = pos
+            drones.append(d)
+            drone_targets.append(d.position)
+        Globals.system_drone_positions = []
+        Globals.entering_drone_count = 0
+        return
+
     var count := Globals.entering_drone_count
     if count <= 0:
         return
@@ -87,6 +99,7 @@ func _connect_asteroids() -> void:
             asteroid.connect("clicked", Callable(self, "_on_asteroid_clicked"))
 
 func _on_asteroid_clicked(click_pos: Vector2) -> void:
+    Globals.space_origin = click_pos
     var positions: Array = []
     for asteroid in get_tree().get_nodes_in_group("asteroid"):
         if asteroid.global_position.distance_to(click_pos) <= asteroid_click_radius:


### PR DESCRIPTION
## Summary
- keep track of the click position used to open the space scene
- remember drone locations when exiting the space scene
- restore drones to those coordinates when returning to the star system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853fb4088488323ba6336a59e3d79b0