### PR TITLE
Improve star appearance with procedural texture

### DIFF
--- a/assets/star.tscn
+++ b/assets/star.tscn
@@ -1,8 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://cwj81lysn86dj"]
+[gd_scene load_steps=3 format=3 uid="uid://cwj81lysn86dj"]
 
 [ext_resource type="Script" uid="uid://cmfxb0d1drs4x" path="res://scripts/star.gd" id="1"]
-
-[sub_resource type="CanvasTexture" id="CanvasTexture_gyjrx"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_3t53c"]
 
@@ -11,15 +9,14 @@ script = ExtResource("1")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2.38419e-07, 2.38419e-07)
-scale = Vector2(16.171, -15.7189)
-texture = SubResource("CanvasTexture_gyjrx")
+scale = Vector2(16, 16)
 offset = Vector2(-2.98023e-08, 0)
 
 [node name="Area2D" type="Area2D" parent="."]
-scale = Vector2(5.05235, 6.29725)
+scale = Vector2(6, 6)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-scale = Vector2(0.221707, 0.184127)
+scale = Vector2(0.25, 0.25)
 shape = SubResource("CircleShape2D_3t53c")
 
 [connection signal="input_event" from="Area2D" to="." method="_on_area_2d_input_event"]

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -10,9 +10,12 @@ extends Node2D
 
 var _default_color: Color
 var _is_last_visited: bool = false
+## Size in pixels of the generated star texture.
+@export var star_texture_size: int = 32
 
 func _ready() -> void:
     _default_color = $Sprite2D.modulate
+    $Sprite2D.texture = _create_star_texture()
 
 ## Handles mouse input on the star. When the player left-clicks the star, the
 ## scene changes to the star system view.
@@ -64,3 +67,18 @@ func _on_area_2d_mouse_exited() -> void:
 func mark_as_last_visited() -> void:
     _is_last_visited = true
     $Sprite2D.modulate = visited_color
+
+func _create_star_texture() -> Texture2D:
+    var size := max(8, star_texture_size)
+    var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+    var center := Vector2(size / 2, size / 2)
+    var radius := size / 2.0
+    for x in size:
+        for y in size:
+            var dist := Vector2(x, y).distance_to(center)
+            var t := clamp(dist / radius, 0.0, 1.0)
+            var a := pow(1.0 - t, 2)
+            img.set_pixel(x, y, Color(1, 1, 1, a))
+    img.generate_mipmaps()
+    var tex := ImageTexture.create_from_image(img)
+    return tex


### PR DESCRIPTION
## Summary
- tweak star scene so the sprite scales evenly
- procedurally draw a radial texture for stars and expose size property

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853fb88051c8323a0b59933dd1f7f89