### PR TITLE
Add manual drone controls and right-click movement

### DIFF
--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -28,6 +28,11 @@ func _ready() -> void:
 func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed('toggle_star_system'):
         get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
+    elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+        var target := get_global_mouse_position()
+        for d in get_tree().get_nodes_in_group("drone"):
+            if d.has_method("move_to"):
+                d.move_to(target)
 
 func _on_back_button_pressed() -> void:
     get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)

--- a/scripts/space_drone.gd
+++ b/scripts/space_drone.gd
@@ -6,8 +6,23 @@ extends Node2D
 @export var mining_rate: float = 1.0
 
 var target: Node2D = null
+var manual_target: Vector2
+var has_manual_target: bool = false
+
+func move_to(pos: Vector2) -> void:
+    manual_target = pos
+    has_manual_target = true
 
 func _process(delta: float) -> void:
+    if has_manual_target:
+        var dist := position.distance_to(manual_target)
+        if dist > 1.0:
+            var dir := (manual_target - position).normalized()
+            position += dir * move_speed * delta
+            return
+        else:
+            has_manual_target = false
+
     if target == null or not is_instance_valid(target):
         target = _find_nearest_asteroid()
     if target == null:

--- a/scripts/star.gd
+++ b/scripts/star.gd
@@ -41,7 +41,7 @@ func _on_star_clicked() -> void:
                 d.belongs_to_star_seed = seed
 
 func _handle_click_event(event: InputEvent) -> void:
-    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
         _on_star_clicked()
 
 func _on_sprite_input_event(viewport: Viewport, event: InputEvent, _shape_idx: int) -> void:

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -114,7 +114,7 @@ func _process(delta: float) -> void:
 func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed('return_to_galaxy') or event.is_action_pressed('toggle_star_system'):
         get_tree().change_scene_to_file('res://scenes/galaxy.tscn')
-    elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+    elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
         var target := get_global_mouse_position()
         for i in range(drone_targets.size()):
             drone_targets[i] = target


### PR DESCRIPTION
## Summary
- control the space drone with right-clicks and only mine automatically when no manual destination is active
- change movement controls to the right mouse button in galaxy, system and space scenes

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fc1c4e2c83239adad2544b1c74e4