### PR TITLE
Improve asteroid generation

### DIFF
--- a/scripts/asteroid.gd
+++ b/scripts/asteroid.gd
@@ -7,19 +7,31 @@ signal mined(global_position: Vector2)
 @export var click_radius: float = 32.0
 @export var color: Color = Color.WHITE
 @export var integrity: float = 1.0
+@export var seed: int = 0
+@export var voxel_size: float = 4.0
 
 var _max_integrity: float = 1.0
 var rng: RandomNumberGenerator = RandomNumberGenerator.new()
+var noise: FastNoiseLite = FastNoiseLite.new()
+var _voxels: Array = []
 
 func _ready() -> void:
-    rng.randomize()
+    if seed == 0:
+        rng.randomize()
+        seed = rng.randi()
+    rng.seed = seed
+    noise.seed = seed
     radius = rng.randf() * 2 * radius
-    _max_integrity = radius
+    _generate_voxels()
+    _max_integrity = float(_voxels.size())
     integrity = _max_integrity
 
 func _draw() -> void:
     var scale := integrity / _max_integrity
-    draw_circle(Vector2.ZERO, radius * scale, color)
+    var size := voxel_size * scale
+    for voxel in _voxels:
+        var pos: Vector2 = voxel * voxel_size * scale
+        draw_rect(Rect2(pos, Vector2(size, size)), color)
 
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
@@ -33,3 +45,15 @@ func mine(amount: float) -> void:
         queue_free()
     else:
         queue_redraw()
+
+func _generate_voxels() -> void:
+    _voxels.clear()
+    noise.noise_type = FastNoiseLite.NOISE_PERLIN
+    noise.frequency = 0.3
+    var grid_radius := int(radius / voxel_size) + 1
+    for x in range(-grid_radius, grid_radius + 1):
+        for y in range(-grid_radius, grid_radius + 1):
+            var dist := Vector2(x, y).length() / grid_radius
+            var n := noise.get_noise_2d(x, y)
+            if n > -dist:
+                _voxels.append(Vector2(x, y))

--- a/scripts/asteroid_belt.gd
+++ b/scripts/asteroid_belt.gd
@@ -7,10 +7,12 @@ var _radius: float = 100.0
 @export var asteroid_count: int = 150
 @export var asteroid_scene: PackedScene = preload("res://assets/asteroid.tscn")
 @export var thickness: float = 100.0
+@export var seed: int = 0
 
 var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 
 func _ready() -> void:
+    rng.seed = seed
     _generate_asteroids()
 
 func set_radius(value: float) -> void:
@@ -21,13 +23,15 @@ func get_radius() -> float:
     return _radius
 
 func _generate_asteroids() -> void:
-    rng.randomize()
+    rng.seed = seed
     for child in get_children():
         child.queue_free()
     for i in range(asteroid_count):
         var asteroid: Node2D = asteroid_scene.instantiate()
         add_child(asteroid)
         asteroid.add_to_group("asteroid")
+        if "seed" in asteroid:
+            asteroid.seed = rng.randi()
         var angle := rng.randf() * TAU
         var r := radius + rng.randf_range(-thickness / 2.0, thickness / 2.0)
         asteroid.position = Vector2(cos(angle), sin(angle)) * r

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -12,6 +12,8 @@ const STAR_SYSTEM_SCENE_PATH := "res://scenes/star_system.tscn"
 var entering_drone_count: int = 0
 ## Positions of asteroids passed to the space scene.
 var space_asteroid_positions: Array = []
+## Seeds of asteroids passed to the space scene.
+var space_asteroid_seeds: Array = []
 ## Relative positions of drones passed to the space scene.
 var space_drone_positions: Array = []
 ## Position where the galaxy drone should reappear when returning from a star system.

--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -6,15 +6,20 @@ extends Node2D
 
 func _ready() -> void:
     var positions := Globals.space_asteroid_positions
-    for pos in positions:
+    var seeds := Globals.space_asteroid_seeds
+    for i in range(positions.size()):
+        var pos = positions[i]
         var asteroid: Node2D = asteroid_scene.instantiate()
         add_child(asteroid)
         asteroid.position = pos * 10
         asteroid.scale *= 10
         asteroid.add_to_group("asteroid")
+        if i < seeds.size() and "seed" in asteroid:
+            asteroid.seed = seeds[i]
         if asteroid.has_signal("mined"):
             asteroid.connect("mined", Callable(self, "_on_asteroid_mined"))
     Globals.space_asteroid_positions = []
+    Globals.space_asteroid_seeds = []
 
     var drone_positions := Globals.space_drone_positions
     for pos in drone_positions:

--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -55,8 +55,11 @@ func _spawn_planets(sun: Node2D) -> void:
         var body: Node2D = (asteroid_belt_scene if is_belt else planet_scene).instantiate()
         add_child(body)
         body.position = sun.position + (Vector2.ZERO if is_belt else offset)
-        if is_belt and "radius" in body:
-            body.radius = offset.length()
+        if is_belt:
+            if "radius" in body:
+                body.radius = offset.length()
+            if "seed" in body:
+                body.seed = rng.randi()
         planets.append(body)
     queue_redraw()
 
@@ -101,10 +104,14 @@ func _connect_asteroids() -> void:
 func _on_asteroid_clicked(click_pos: Vector2) -> void:
     Globals.space_origin = click_pos
     var positions: Array = []
+    var seeds: Array = []
     for asteroid in get_tree().get_nodes_in_group("asteroid"):
         if asteroid.global_position.distance_to(click_pos) <= asteroid_click_radius:
             positions.append(asteroid.global_position - click_pos)
+            if "seed" in asteroid:
+                seeds.append(asteroid.seed)
     Globals.space_asteroid_positions = positions
+    Globals.space_asteroid_seeds = seeds
 
     var drone_positions: Array = []
     for d in drones:


### PR DESCRIPTION
## Summary
- give asteroids and asteroid belts deterministic seeds
- generate voxel-based asteroid shapes using seeded Perlin noise
- preserve asteroid seeds when switching to the space scene

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68540261bfb08323bee4e434eb3db37f