### PR TITLE
Add drone building system

### DIFF
--- a/assets/drone_blueprint.tscn
+++ b/assets/drone_blueprint.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://droneblueprint"]
+
+[ext_resource type="Script" path="res://scripts/drone_blueprint.gd" id="1"]
+
+[node name="DroneBlueprint" type="Node2D"]
+script = ExtResource("1")

--- a/scenes/space.tscn
+++ b/scenes/space.tscn
@@ -10,6 +10,25 @@ script = ExtResource("1")
 
 [node name="UI" type="CanvasLayer" parent="."]
 
+[node name="BuildToggle" type="Button" parent="UI"]
+offset_left = 10.0
+offset_top = 10.0
+text = "Build"
+
+[node name="BuildPanel" type="Panel" parent="UI"]
+visible = false
+offset_left = 10.0
+offset_top = 50.0
+offset_right = 110.0
+offset_bottom = 150.0
+
+[node name="DroneButton" type="Button" parent="UI/BuildPanel"]
+layout_mode = 0
+anchor_right = 1.0
+offset_right = -10.0
+offset_bottom = 30.0
+text = "Drone"
+
 [node name="BottomPanel" type="Panel" parent="UI"]
 anchors_preset = 12
 anchor_top = 1.0
@@ -29,3 +48,5 @@ offset_bottom = -10.0
 text = "Back to System"
 
 [connection signal="pressed" from="UI/BottomPanel/BackButton" to="." method="_on_back_button_pressed"]
+[connection signal="pressed" from="UI/BuildToggle" to="." method="_on_build_toggle_pressed"]
+[connection signal="pressed" from="UI/BuildPanel/DroneButton" to="." method="_on_drone_button_pressed"]

--- a/scripts/drone_blueprint.gd
+++ b/scripts/drone_blueprint.gd
@@ -1,0 +1,31 @@
+extends Node2D
+
+@export var required_iron: int = 5
+@export var drone_scene: PackedScene = preload("res://assets/space_drone.tscn")
+
+var current_iron: int = 0
+
+func _ready() -> void:
+    add_to_group("drone_blueprint")
+    queue_redraw()
+
+func add_iron() -> void:
+    current_iron += 1
+    if current_iron >= required_iron:
+        _spawn_drone()
+    queue_redraw()
+
+func _spawn_drone() -> void:
+    if drone_scene == null:
+        return
+    var d: Node2D = drone_scene.instantiate()
+    get_parent().add_child(d)
+    d.global_position = global_position
+    d.scale *= 10
+    d.add_to_group("drone")
+    queue_free()
+
+func _draw() -> void:
+    draw_circle(Vector2.ZERO, 10.0, Color(0.2, 0.6, 1.0, 0.5))
+    var angle := TAU * float(current_iron) / float(required_iron)
+    draw_arc(Vector2.ZERO, 12.0, -PI / 2.0, angle, 16, Color.AQUA)

--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -3,6 +3,9 @@ extends Node2D
 @export var asteroid_scene: PackedScene = preload("res://assets/space_asteroid.tscn")
 @export var drone_scene: PackedScene = preload("res://assets/space_drone.tscn")
 @export var processed_iron_scene: PackedScene = preload("res://assets/processed_iron.tscn")
+@export var blueprint_scene: PackedScene = preload("res://assets/drone_blueprint.tscn")
+
+var build_mode: String = ""
 
 func _ready() -> void:
     var positions := Globals.space_asteroid_positions
@@ -35,6 +38,19 @@ func _ready() -> void:
     Globals.space_drone_positions = []
 
 func _unhandled_input(event: InputEvent) -> void:
+    if build_mode != "":
+        if event is InputEventMouseButton:
+            if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+                if build_mode == "drone" and blueprint_scene:
+                    var bp: Node2D = blueprint_scene.instantiate()
+                    add_child(bp)
+                    bp.global_position = get_global_mouse_position()
+                    bp.scale *= 10
+                return
+            elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+                build_mode = ""
+                return
+
     if event.is_action_pressed('toggle_star_system'):
         _save_system_drone_positions()
         get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
@@ -48,6 +64,14 @@ func _on_back_button_pressed() -> void:
     _save_system_drone_positions()
     get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
 
+func _on_build_toggle_pressed() -> void:
+    if has_node("UI/BuildPanel"):
+        var panel = get_node("UI/BuildPanel")
+        panel.visible = !panel.visible
+
+func _on_drone_button_pressed() -> void:
+    build_mode = "drone"
+
 func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:
     if processed_iron_scene == null:
         return
@@ -55,6 +79,7 @@ func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:
     add_child(iron)
     iron.global_position = global_pos
     iron.scale *= 10
+    iron.add_to_group("processed_iron")
     var belt_seed := 0
     if "belt_seed" in asteroid:
         belt_seed = asteroid.belt_seed

--- a/scripts/space_drone.gd
+++ b/scripts/space_drone.gd
@@ -8,6 +8,8 @@ extends Node2D
 var target: Node2D = null
 var manual_target: Vector2
 var has_manual_target: bool = false
+var carrying: Node2D = null
+var deliver_target: Node2D = null
 
 func move_to(pos: Vector2) -> void:
     manual_target = pos
@@ -22,6 +24,35 @@ func _process(delta: float) -> void:
             return
         else:
             has_manual_target = false
+    if carrying != null:
+        if deliver_target == null or not is_instance_valid(deliver_target):
+            deliver_target = _find_nearest_blueprint()
+        if deliver_target == null:
+            carrying.queue_free()
+            carrying = null
+            return
+        var dist := position.distance_to(deliver_target.global_position)
+        if dist > mining_range:
+            var dir := (deliver_target.global_position - position).normalized()
+            position += dir * move_speed * delta
+        else:
+            if deliver_target.has_method("add_iron"):
+                deliver_target.add_iron()
+            carrying.queue_free()
+            carrying = null
+            deliver_target = null
+        return
+
+    var iron := _find_nearest_processed_iron()
+    var blueprint := _find_nearest_blueprint()
+    if iron != null and blueprint != null:
+        var dist := position.distance_to(iron.global_position)
+        if dist > mining_range:
+            var dir := (iron.global_position - position).normalized()
+            position += dir * move_speed * delta
+        else:
+            carrying = iron
+        return
 
     if target == null or not is_instance_valid(target):
         target = _find_nearest_asteroid()
@@ -38,11 +69,31 @@ func _process(delta: float) -> void:
                 target = null
 
 func _find_nearest_asteroid() -> Node2D:
-    var nearest 
+    var nearest
     var nearest_dist := detection_range
     for asteroid in get_tree().get_nodes_in_group("asteroid"):
         var d := position.distance_to(asteroid.global_position)
         if d < nearest_dist:
             nearest_dist = d
             nearest = asteroid
+    return nearest
+
+func _find_nearest_processed_iron() -> Node2D:
+    var nearest
+    var nearest_dist := detection_range
+    for iron in get_tree().get_nodes_in_group("processed_iron"):
+        var d := position.distance_to(iron.global_position)
+        if d < nearest_dist:
+            nearest_dist = d
+            nearest = iron
+    return nearest
+
+func _find_nearest_blueprint() -> Node2D:
+    var nearest
+    var nearest_dist := detection_range
+    for bp in get_tree().get_nodes_in_group("drone_blueprint"):
+        var d := position.distance_to(bp.global_position)
+        if d < nearest_dist:
+            nearest_dist = d
+            nearest = bp
     return nearest


### PR DESCRIPTION
## Summary
- add drone blueprint scene and script
- spawn processed iron in a dedicated group
- add expandable build menu in the space scene
- allow placing drone blueprints and canceling build mode
- extend drone logic to haul iron to blueprints until a drone is built

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854414f4db08323bdfcae40f610058d