### PR TITLE
Fix resource pickup timing

### DIFF
--- a/scripts/space_drone.gd
+++ b/scripts/space_drone.gd
@@ -43,7 +43,6 @@ func _process(delta: float) -> void:
         if deliver_target == null or not is_instance_valid(deliver_target):
             deliver_target = _find_nearest_blueprint()
         if deliver_target == null:
-            carrying.queue_free()
             carrying = null
             return
         var dist := position.distance_to(deliver_target.global_position)
@@ -53,7 +52,6 @@ func _process(delta: float) -> void:
         else:
             if deliver_target.has_method("add_iron"):
                 deliver_target.add_iron()
-            carrying.queue_free()
             carrying = null
             deliver_target = null
         return
@@ -67,6 +65,7 @@ func _process(delta: float) -> void:
             position += dir * move_speed * delta
         else:
             carrying = iron
+            iron.queue_free()
         return
 
     if target == null or not is_instance_valid(target):


### PR DESCRIPTION
## Summary
- free processed iron when a drone picks it up
- avoid freeing nonexistent iron when delivering to a blueprint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685446701f9083239e2e2edda0fa64ad