### PR TITLE
Fix building workflow and support multiple materials

### DIFF
--- a/scripts/drone_blueprint.gd
+++ b/scripts/drone_blueprint.gd
@@ -1,19 +1,28 @@
 extends Node2D
 
-@export var required_iron: int = 5
+## Materials required to finish this blueprint. Each key is a material type
+## and the value is the amount needed.
+@export var required_materials: Dictionary = {"iron": 5}
 @export var drone_scene: PackedScene = preload("res://assets/space_drone.tscn")
 
-var current_iron: int = 0
+var current_materials: Dictionary = {}
 
 func _ready() -> void:
     add_to_group("drone_blueprint")
     queue_redraw()
 
-func add_iron() -> void:
-    current_iron += 1
-    if current_iron >= required_iron:
-        _spawn_drone()
+func add_material(material_type: String) -> void:
+    var current := current_materials.get(material_type, 0)
+    current += 1
+    current_materials[material_type] = current
+    _check_completion()
     queue_redraw()
+
+func _check_completion() -> void:
+    for mat in required_materials.keys():
+        if current_materials.get(mat, 0) < required_materials[mat]:
+            return
+    _spawn_drone()
 
 func _spawn_drone() -> void:
     if drone_scene == null:
@@ -27,5 +36,12 @@ func _spawn_drone() -> void:
 
 func _draw() -> void:
     draw_circle(Vector2.ZERO, 10.0, Color(0.2, 0.6, 1.0, 0.5))
-    var angle := TAU * float(current_iron) / float(required_iron)
+    var required_total := 0.0
+    var current_total := 0.0
+    for mat in required_materials.keys():
+        required_total += float(required_materials[mat])
+        current_total += float(current_materials.get(mat, 0))
+    if required_total <= 0.0:
+        return
+    var angle := TAU * (current_total / required_total)
     draw_arc(Vector2.ZERO, 12.0, -PI / 2.0, angle, 16, Color.AQUA)

--- a/scripts/processed_iron.gd
+++ b/scripts/processed_iron.gd
@@ -2,6 +2,10 @@ extends Node2D
 
 @export var size: float = 4.0
 @export var color: Color = Color.BURLYWOOD
+@export var material_type: String = "iron"
+
+func _ready() -> void:
+    add_to_group("processed_material")
 
 func _draw() -> void:
     draw_rect(Rect2(Vector2(-size / 2, -size / 2), Vector2(size, size)), color)

--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 @export var asteroid_scene: PackedScene = preload("res://assets/space_asteroid.tscn")
 @export var drone_scene: PackedScene = preload("res://assets/space_drone.tscn")
-@export var processed_iron_scene: PackedScene = preload("res://assets/processed_iron.tscn")
+@export var processed_material_scene: PackedScene = preload("res://assets/processed_iron.tscn")
 @export var blueprint_scene: PackedScene = preload("res://assets/drone_blueprint.tscn")
 
 var build_mode: String = ""
@@ -73,13 +73,13 @@ func _on_drone_button_pressed() -> void:
     build_mode = "drone"
 
 func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:
-    if processed_iron_scene == null:
+    if processed_material_scene == null:
         return
-    var iron: Node2D = processed_iron_scene.instantiate()
+    var iron: Node2D = processed_material_scene.instantiate()
     add_child(iron)
     iron.global_position = global_pos
     iron.scale *= 10
-    iron.add_to_group("processed_iron")
+    iron.add_to_group("processed_material")
     var belt_seed := 0
     if "belt_seed" in asteroid:
         belt_seed = asteroid.belt_seed

--- a/scripts/space_drone.gd
+++ b/scripts/space_drone.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 @export var move_speed: float = 50.0
-@export var detection_range: float = 800.0
+@export var detection_range: float = 4000.0
 @export var mining_range: float = 20.0
 @export var mining_rate: float = 1.0
 ## Minimum distance this drone tries to keep from other drones.
@@ -10,7 +10,7 @@ extends Node2D
 var asteroid_target: Node2D = null
 var manual_destination: Vector2
 var manual_destination_active: bool = false
-var carried_iron: Node2D = null
+var carried_material: Node2D = null
 var blueprint_target: Node2D = null
 
 ## Push away from nearby drones to avoid clumping.
@@ -39,24 +39,24 @@ func _process(delta: float) -> void:
             return
         else:
             manual_destination_active = false
-    if carried_iron != null:
+    if carried_material != null:
         if blueprint_target == null or not is_instance_valid(blueprint_target):
             blueprint_target = _get_nearest_blueprint()
         if blueprint_target == null:
-            carried_iron = null
+            carried_material = null
             return
         var dist := position.distance_to(blueprint_target.global_position)
         if dist > mining_range:
             var dir := (blueprint_target.global_position - position).normalized()
             position += dir * move_speed * delta
         else:
-            if blueprint_target.has_method("add_iron"):
-                blueprint_target.add_iron()
-            carried_iron = null
+            if blueprint_target.has_method("add_material"):
+                blueprint_target.add_material(carried_material.material_type)
+            carried_material = null
             blueprint_target = null
         return
 
-    var iron := _get_nearest_processed_iron()
+    var iron := _get_nearest_material()
     var blueprint := _get_nearest_blueprint()
     if iron != null and blueprint != null:
         var dist := position.distance_to(iron.global_position)
@@ -64,7 +64,7 @@ func _process(delta: float) -> void:
             var dir := (iron.global_position - position).normalized()
             position += dir * move_speed * delta
         else:
-            carried_iron = iron
+            carried_material = iron
             iron.queue_free()
         return
 
@@ -92,10 +92,10 @@ func _get_nearest_asteroid() -> Node2D:
             closest = asteroid
     return closest
 
-func _get_nearest_processed_iron() -> Node2D:
+func _get_nearest_material() -> Node2D:
     var closest
     var closest_distance := detection_range
-    for iron in get_tree().get_nodes_in_group("processed_iron"):
+    for iron in get_tree().get_nodes_in_group("processed_material"):
         var distance := position.distance_to(iron.global_position)
         if distance < closest_distance:
             closest_distance = distance


### PR DESCRIPTION
## Summary
- let processed resources track their material type
- allow blueprints to accept any material and compute build progress based on requirements
- handle generic materials in `space_drone.gd`
- spawn processed materials under a generic group

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854483ba8e88323a9456b85b0120c6b