### PR TITLE
Refactor: extract shared helpers

### DIFF
--- a/scripts/star_system.gd
+++ b/scripts/star_system.gd
@@ -2,6 +2,8 @@ extends Node2D
 
 const StarSystemGenerator = preload('res://scripts/generators/star_system_generator.gd')
 const StarSystemDroneManager = preload('res://scripts/star_system_drone_manager.gd')
+const BeltManager = preload("res://scripts/utils/belt_manager.gd")
+const SelectionUtils = preload("res://scripts/utils/selection_utils.gd")
 
 ## Scene used for the system's star.
 @export var sun_scene: PackedScene = preload('res://assets/sun.tscn')
@@ -114,23 +116,6 @@ func _connect_asteroids() -> void:
         if asteroid.has_signal("clicked"):
             asteroid.connect("clicked", Callable(self, "_on_asteroid_clicked").bind(asteroid))
 
-func _set_drone_selected(d: Node2D, selected: bool) -> void:
-    var sprite: Sprite2D = d.get_node_or_null("Sprite2D")
-    if sprite:
-        sprite.modulate = (Color.YELLOW if selected else Color.WHITE)
-
-func _clear_selection() -> void:
-    for d in selected_drones:
-        _set_drone_selected(d, false)
-    selected_drones.clear()
-
-func _apply_selection(rect: Rect2) -> void:
-    _clear_selection()
-    rect = rect.abs()
-    for d in get_tree().get_nodes_in_group("drone"):
-        if rect.has_point(d.global_position):
-            selected_drones.append(d)
-            _set_drone_selected(d, true)
 
 func _on_asteroid_clicked(click_pos: Vector2, src: Node) -> void:
     Globals.space_origin = click_pos
@@ -180,7 +165,7 @@ func _unhandled_input(event: InputEvent) -> void:
                 selecting = false
                 var rect := Rect2(select_start, get_global_mouse_position() - select_start)
                 rect = rect.abs()
-                _apply_selection(rect)
+                SelectionUtils.apply_selection(self, rect, selected_drones)
                 select_rect = Rect2()
                 queue_redraw()
         elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:

--- a/scripts/utils/belt_manager.gd
+++ b/scripts/utils/belt_manager.gd
@@ -1,0 +1,63 @@
+extends Node
+
+class_name BeltManager
+
+static func apply_mining_to_asteroids(owner: Node, key: String) -> void:
+    var percent = Globals.belt_mining_percent.get(key, 0.0)
+    if percent <= 0.0:
+        return
+    for asteroid in owner.get_tree().get_nodes_in_group("asteroid"):
+        if not ("seed" in asteroid):
+            continue
+        var r := RandomNumberGenerator.new()
+        r.seed = int(asteroid.seed) + Globals.space_belt_seed + Globals.star_seed
+        if r.randf() < percent:
+            asteroid.queue_free()
+
+static func apply_offline_progress(key: String) -> void:
+    var offline_progress_factor = 0.05
+    var last_time = Globals.belt_last_loaded.get(key, 0)
+    var now := Time.get_unix_time_from_system()
+    if last_time == 0:
+        Globals.belt_last_loaded[key] = now
+        return
+    var counts: Dictionary = Globals.belt_drones.get(key, {})
+    if counts.is_empty():
+        Globals.belt_last_loaded[key] = now
+        return
+    var mined_total := 0.0
+    var total_asteroids = Globals.belt_asteroid_count.get(key, 1)
+    var total_integrity = Globals.belt_total_integrity.get(key, float(total_asteroids))
+    for scene_path in counts.keys():
+        var scene := load(scene_path)
+        if scene == null:
+            continue
+        var inst = scene.instantiate()
+        var rate := 0.0
+        if "mining_rate" in inst:
+            rate = inst.mining_rate
+        var speed := 0.0
+        if "move_speed" in inst:
+            speed = inst.move_speed
+        inst.free()
+        mined_total += float(counts[scene_path]) * rate * float(now - last_time) * offline_progress_factor / (total_integrity / speed)
+    var percent = Globals.belt_mining_percent.get(key, 0.0)
+    percent += mined_total / float(total_integrity)
+    Globals.belt_mining_percent[key] = clamp(percent, 0.0, 1.0)
+    Globals.belt_last_loaded[key] = now
+
+static func record_belt_state(owner: Node, drone_scene: PackedScene) -> void:
+    var belt_seed := Globals.space_belt_seed
+    if belt_seed == 0:
+        return
+    var key := str(Globals.star_seed) + "_" + str(belt_seed)
+    var counts: Dictionary = {}
+    for d in owner.get_tree().get_nodes_in_group("drone"):
+        var path := ""
+        if d.has_meta("scene_path"):
+            path = str(d.get_meta("scene_path"))
+        else:
+            path = drone_scene.resource_path
+        counts[path] = counts.get(path, 0) + 1
+    Globals.belt_drones[key] = counts
+    Globals.belt_last_loaded[key] = Time.get_unix_time_from_system()

--- a/scripts/utils/selection_utils.gd
+++ b/scripts/utils/selection_utils.gd
@@ -1,0 +1,21 @@
+extends Node
+
+class_name SelectionUtils
+
+static func set_selected(d: Node2D, selected: bool) -> void:
+    var sprite: Sprite2D = d.get_node_or_null("Sprite2D")
+    if sprite:
+        sprite.modulate = (Color.YELLOW if selected else Color.WHITE)
+
+static func clear_selection(selected_drones: Array) -> void:
+    for d in selected_drones:
+        set_selected(d, false)
+    selected_drones.clear()
+
+static func apply_selection(owner: Node, rect: Rect2, selected_drones: Array) -> void:
+    clear_selection(selected_drones)
+    rect = rect.abs()
+    for d in owner.get_tree().get_nodes_in_group("drone"):
+        if rect.has_point(d.global_position):
+            selected_drones.append(d)
+            set_selected(d, true)


### PR DESCRIPTION
## Summary
- centralize belt logic in `BeltManager`
- add `SelectionUtils` to reuse selection code
- use the new helpers in space and star system scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855ac4379d48323aac65673d5c91a18