### PR TITLE
Add offline mining material storage

### DIFF
--- a/scripts/space.gd
+++ b/scripts/space.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
     var seeds := Globals.space_asteroid_seeds
     var belt_seed := Globals.space_belt_seed
     var key := str(Globals.star_seed) + "_" + str(belt_seed)
-    BeltManager.apply_offline_progress(key)
+    BeltManager.apply_offline_progress(self, null, key)
     for i in range(positions.size()):
         var pos = positions[i]
         var asteroid: Node2D = asteroid_scene.instantiate()

--- a/scripts/utils/belt_manager.gd
+++ b/scripts/utils/belt_manager.gd
@@ -2,6 +2,26 @@ extends Node
 
 class_name BeltManager
 
+static func _cluster_with_room(owner: Node) -> Node:
+    for c in owner.get_tree().get_nodes_in_group("material_cluster"):
+        if "stored_amount" in c and "capacity" in c:
+            if c.stored_amount < c.capacity:
+                return c
+    return null
+
+static func add_material_to_clusters(owner: Node, cluster_scene: PackedScene, material_type: String, amount: int) -> void:
+    for i in range(amount):
+        var cluster := _cluster_with_room(owner)
+        if cluster == null:
+            if cluster_scene == null:
+                return
+            cluster = cluster_scene.instantiate()
+            owner.add_child(cluster)
+            cluster.position = Vector2.ZERO
+            cluster.scale *= 10
+        if cluster.has_method("add_material"):
+            cluster.add_material(material_type)
+
 static func apply_mining_to_asteroids(owner: Node, key: String) -> void:
     var percent = Globals.belt_mining_percent.get(key, 0.0)
     if percent <= 0.0:
@@ -14,7 +34,7 @@ static func apply_mining_to_asteroids(owner: Node, key: String) -> void:
         if r.randf() < percent:
             asteroid.queue_free()
 
-static func apply_offline_progress(key: String) -> void:
+static func apply_offline_progress(owner: Node, cluster_scene: PackedScene, key: String) -> void:
     var offline_progress_factor = 0.05
     var last_time = Globals.belt_last_loaded.get(key, 0)
     var now := Time.get_unix_time_from_system()
@@ -45,6 +65,10 @@ static func apply_offline_progress(key: String) -> void:
     percent += mined_total / float(total_integrity)
     Globals.belt_mining_percent[key] = clamp(percent, 0.0, 1.0)
     Globals.belt_last_loaded[key] = now
+
+    var material_count := int(mined_total)
+    if material_count > 0:
+        add_material_to_clusters(owner, cluster_scene, "iron", material_count)
 
 static func record_belt_state(owner: Node, drone_scene: PackedScene) -> void:
     var belt_seed := Globals.space_belt_seed

--- a/scripts/world/space.gd
+++ b/scripts/world/space.gd
@@ -20,7 +20,14 @@ func _ready() -> void:
     var seeds := Globals.space_asteroid_seeds
     var belt_seed := Globals.space_belt_seed
     var key := str(Globals.star_seed) + "_" + str(belt_seed)
-    BeltManager.apply_offline_progress(key)
+
+    if material_cluster_scene:
+        var cluster := material_cluster_scene.instantiate()
+        add_child(cluster)
+        cluster.position = Vector2.ZERO
+        cluster.scale *= 10
+
+    BeltManager.apply_offline_progress(self, material_cluster_scene, key)
     for i in range(positions.size()):
         var pos = positions[i]
         var asteroid: Node2D = asteroid_scene.instantiate()
@@ -61,11 +68,6 @@ func _ready() -> void:
                 d.add_to_group("drone")
                 d.set_meta("scene_path", scene_path)
 
-    if material_cluster_scene:
-        var cluster: Node2D = material_cluster_scene.instantiate()
-        add_child(cluster)
-        cluster.position = Vector2.ZERO
-        cluster.scale *= 10
 
 func _draw() -> void:
     if selecting:
@@ -132,13 +134,8 @@ func _on_drone_button_pressed() -> void:
 
 
 func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:
-    if processed_material_scene == null:
-        return
-    var iron: Node2D = processed_material_scene.instantiate()
-    add_child(iron)
-    iron.global_position = global_pos
-    iron.scale *= 10
-    iron.add_to_group("processed_material")
+    if material_cluster_scene:
+        BeltManager.add_material_to_clusters(self, material_cluster_scene, "iron", 1)
     var belt_seed := 0
     if "belt_seed" in asteroid:
         belt_seed = asteroid.belt_seed


### PR DESCRIPTION
## Summary
- ensure offline progress puts mined materials into nearby clusters
- spawn a cluster if none has free capacity before delivering materials
- deliver mined materials straight to clusters during gameplay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68580bfe358c83239589c8526f71e6bf