### PR TITLE
Add carrier drone type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Hegswarm is a small project written in **Godot version 4**. The core idea is to 
 - **Automation**: Build factories and additional drones to automate resource gathering and production.
 - **Exploration and Expansion**: Use new drones to scout distant systems, expanding your reach and discovering more materials.
 - **Resource Management**: Balance mined materials between expanding your swarm and powering existing structures.
+- **Carrier Drones**: Specialized drones that can store and unload other drones for rapid transportation.
 
 The project is in its early stages, so feel free to experiment with the world generation script in `scripts/world/world_generation.gd`.
 

--- a/assets/drones/carrier_drone.tscn
+++ b/assets/drones/carrier_drone.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=3 format=3 uid="uid://skacsy6btsc4"]
+[gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" uid="uid://cdxla0n8e4wb7" path="res://scripts/entities/space_drone.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/entities/space_drone.gd" id="1"]
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_planet"]
 
-[node name="SpaceDrone" type="Node2D"]
+[node name="CarrierDrone" type="Node2D"]
 scale = Vector2(4.42367, 4.3384)
 script = ExtResource("1")
 move_speed = 780.0
@@ -12,7 +12,7 @@ detection_range = 2000.0
 mining_range = 120.0
 mining_rate = 2225.0
 separation_distance = 100.0
-storeable_amount = 0
+storeable_amount = 5
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 scale = Vector2(1.96826, -0.642853)

--- a/assets/drones/carrier_drone_blueprint.tscn
+++ b/assets/drones/carrier_drone_blueprint.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/entities/drone_blueprint.gd" id="1"]
+[ext_resource type="PackedScene" path="res://assets/drones/carrier_drone.tscn" id="2"]
+
+[node name="DroneBlueprint" type="Node2D"]
+script = ExtResource("1")
+drone_scene = ExtResource("2")

--- a/scenes/space.tscn
+++ b/scenes/space.tscn
@@ -29,6 +29,14 @@ offset_right = -10.0
 offset_bottom = 30.0
 text = "Drone"
 
+[node name="CarrierButton" type="Button" parent="UI/BuildPanel"]
+layout_mode = 0
+anchor_right = 1.0
+offset_top = 40.0
+offset_right = -10.0
+offset_bottom = 70.0
+text = "Carrier"
+
 [node name="BottomPanel" type="Panel" parent="UI"]
 anchors_preset = 12
 anchor_top = 1.0
@@ -49,4 +57,5 @@ text = "Back to System"
 
 [connection signal="pressed" from="UI/BuildToggle" to="." method="_on_build_toggle_pressed"]
 [connection signal="pressed" from="UI/BuildPanel/DroneButton" to="." method="_on_drone_button_pressed"]
+[connection signal="pressed" from="UI/BuildPanel/CarrierButton" to="." method="_on_carrier_button_pressed"]
 [connection signal="pressed" from="UI/BottomPanel/BackButton" to="." method="_on_back_button_pressed"]

--- a/scripts/world/space.gd
+++ b/scripts/world/space.gd
@@ -10,12 +10,14 @@ const SelectionUtils = preload("res://scripts/utils/selection_utils.gd")
 @export var material_cluster_scene: PackedScene = preload("res://assets/materials/material_cluster.tscn")
 
 var build_mode: String = ""
+var blueprint_drone_scene: PackedScene
 var selected_drones: Array = []
 var selecting: bool = false
 var select_start: Vector2
 var select_rect: Rect2 = Rect2()
 
 func _ready() -> void:
+    blueprint_drone_scene = drone_scene
     var positions := Globals.space_asteroid_positions
     var seeds := Globals.space_asteroid_seeds
     var belt_seed := Globals.space_belt_seed
@@ -93,6 +95,8 @@ func _unhandled_input(event: InputEvent) -> void:
                     bp.scale *= 10
                     if "cluster_scene" in bp:
                         bp.cluster_scene = material_cluster_scene
+                    if "drone_scene" in bp and blueprint_drone_scene:
+                        bp.drone_scene = blueprint_drone_scene
                 return
             elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
                 build_mode = ""
@@ -134,6 +138,11 @@ func _on_build_toggle_pressed() -> void:
 
 func _on_drone_button_pressed() -> void:
     build_mode = "drone"
+    blueprint_drone_scene = drone_scene
+
+func _on_carrier_button_pressed() -> void:
+    build_mode = "drone"
+    blueprint_drone_scene = preload("res://assets/drones/carrier_drone.tscn")
 
 
 func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:


### PR DESCRIPTION
## Summary
- add storeable drone capacity to the drone script
- implement storing and unloading drones
- set normal drone capacity to zero and create new carrier drone scene with capacity
- document carrier drones in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f04437a8c8323aa072be1856b93b3