### PR TITLE
Limit galaxy drones to carriers and allow selection

### DIFF
--- a/scripts/entities/galaxy_drone.gd
+++ b/scripts/entities/galaxy_drone.gd
@@ -11,6 +11,7 @@ var path_line: Node2D
 
 func _ready() -> void:
     add_to_group("galaxy_drone")
+    add_to_group("drone")
     target_position = position
     path_line = preload("res://scripts/utils/path_line.gd").new()
     path_line.set_as_top_level(true)

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -148,7 +148,9 @@ func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed('return_to_galaxy') or event.is_action_pressed('toggle_star_system'):
         var count := 0
         if drone_manager:
-            count = drone_manager.get_drones().size()
+            for d in drone_manager.get_drones():
+                if "storeable_amount" in d and d.storeable_amount > 0:
+                    count += 1
         Globals.returning_drone_count = count
         var star_counts: Dictionary = Globals.star_drone_counts.get(Globals.star_seed, {})
         star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
@@ -182,7 +184,9 @@ func _unhandled_input(event: InputEvent) -> void:
 func _on_back_button_pressed() -> void:
     var count := 0
     if drone_manager:
-        count = drone_manager.get_drones().size()
+        for d in drone_manager.get_drones():
+            if "storeable_amount" in d and d.storeable_amount > 0:
+                count += 1
     Globals.returning_drone_count = count
     var star_counts: Dictionary = Globals.star_drone_counts.get(Globals.star_seed, {})
     star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count


### PR DESCRIPTION
## Summary
- put galaxy drones in the generic `drone` group
- count only carrier drones when leaving a star system
- enable selecting and commanding drones in the galaxy view

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685f076e6fcc8323bdf01e43b9f64462