### PR TITLE
Refactor offline progress handling

### DIFF
--- a/scripts/utils/belt_manager.gd
+++ b/scripts/utils/belt_manager.gd
@@ -2,6 +2,8 @@ extends Node
 
 class_name BeltManager
 
+const BeltOfflineProgress = preload("res://scripts/utils/belt_offline_progress.gd")
+
 static func _cluster_with_room(owner: Node) -> Node:
     for c in owner.get_tree().get_nodes_in_group("material_cluster"):
         if "stored_amount" in c and "capacity" in c:
@@ -35,64 +37,14 @@ static func apply_mining_to_asteroids(owner: Node, key: String) -> void:
             asteroid.queue_free()
 
 static func apply_offline_progress(owner: Node, cluster_scene: PackedScene, key: String) -> void:
-    var offline_progress_factor = 0.05
-    var transport_time_per_material = 1.0
-    var last_time = Globals.belt_last_loaded.get(key, 0)
-    var now := Time.get_unix_time_from_system()
-    if last_time == 0:
-        Globals.belt_last_loaded[key] = now
-        return
-    var counts: Dictionary = Globals.belt_drones.get(key, {})
-    var mined_total := 0.0
-    if not counts.is_empty():
-        var total_asteroids = Globals.belt_asteroid_count.get(key, 1)
-        var total_integrity = Globals.belt_total_integrity.get(key, float(total_asteroids))
-        for scene_path in counts.keys():
-            var scene := load(scene_path)
-            if scene == null:
-                continue
-            var inst = scene.instantiate()
-            var rate := 0.0
-            if "mining_rate" in inst:
-                rate = inst.mining_rate
-            var speed := 0.0
-            if "move_speed" in inst:
-                speed = inst.move_speed
-            inst.free()
-            mined_total += float(counts[scene_path]) * rate * float(now - last_time) * offline_progress_factor / (total_integrity / speed)
-        var percent = Globals.belt_mining_percent.get(key, 0.0)
-        percent += mined_total / float(total_integrity)
-        Globals.belt_mining_percent[key] = clamp(percent, 0.0, 1.0)
-
-    var mined_materials := int(mined_total)
-    var cluster_materials = Globals.belt_cluster_iron.get(key, 0)
-    var blueprint_count = Globals.belt_blueprint_counts.get(key, 0)
-    var blueprint_needed = Globals.belt_blueprint_iron_needed.get(key, blueprint_count * 5)
-
-    var available = mined_materials + cluster_materials
-    var deliverable = min(available, int(float(now - last_time) / transport_time_per_material))
-    var built = min(blueprint_count, int(deliverable))
-    built = min(built, int(blueprint_needed))
-
-    if built > 0:
-        var drone_path := preload("res://assets/drones/space_drone.tscn").resource_path
-        counts[drone_path] = counts.get(drone_path, 0) + built
-        available -= built * 5
-        blueprint_count -= built
-        blueprint_needed -= built * 5
-
-    Globals.belt_drones[key] = counts
-    Globals.belt_blueprint_counts[key] = blueprint_count
-    Globals.belt_blueprint_iron_needed[key] = blueprint_needed
-
+    var calc := BeltOfflineProgress.new()
+    var available := calc.apply(key)
     if cluster_scene != null:
         if available > 0:
             add_material_to_clusters(owner, cluster_scene, "iron", available)
         Globals.belt_cluster_iron[key] = 0
     else:
         Globals.belt_cluster_iron[key] = available
-
-    Globals.belt_last_loaded[key] = now
 
 static func record_belt_state(owner: Node, drone_scene: PackedScene) -> void:
     var belt_seed := Globals.space_belt_seed

--- a/scripts/utils/belt_offline_progress.gd
+++ b/scripts/utils/belt_offline_progress.gd
@@ -1,0 +1,64 @@
+extends RefCounted
+
+class_name BeltOfflineProgress
+
+var offline_progress_factor: float = 0.05
+var transport_time_per_material: float = 1.0
+
+func apply(key: String) -> int:
+    var last_time = Globals.belt_last_loaded.get(key, 0)
+    var now := Time.get_unix_time_from_system()
+    if last_time == 0:
+        Globals.belt_last_loaded[key] = now
+        return 0
+
+    var counts: Dictionary = Globals.belt_drones.get(key, {})
+    var mined_total := _calculate_mined_total(counts, last_time, now, key)
+    var available := _apply_blueprints(counts, mined_total, last_time, now, key)
+
+    Globals.belt_last_loaded[key] = now
+    return available
+
+func _calculate_mined_total(counts: Dictionary, last_time: int, now: int, key: String) -> float:
+    var mined_total := 0.0
+    if counts.is_empty():
+        return mined_total
+    var total_asteroids = Globals.belt_asteroid_count.get(key, 1)
+    var total_integrity = Globals.belt_total_integrity.get(key, float(total_asteroids))
+    for scene_path in counts.keys():
+        var scene := load(scene_path)
+        if scene == null:
+            continue
+        var inst = scene.instantiate()
+        var rate := 0.0
+        if "mining_rate" in inst:
+            rate = inst.mining_rate
+        var speed := 0.0
+        if "move_speed" in inst:
+            speed = inst.move_speed
+        inst.free()
+        mined_total += float(counts[scene_path]) * rate * float(now - last_time) * offline_progress_factor / (total_integrity / speed)
+    var percent = Globals.belt_mining_percent.get(key, 0.0)
+    percent += mined_total / float(total_integrity)
+    Globals.belt_mining_percent[key] = clamp(percent, 0.0, 1.0)
+    return mined_total
+
+func _apply_blueprints(counts: Dictionary, mined_total: float, last_time: int, now: int, key: String) -> int:
+    var mined_materials := int(mined_total)
+    var cluster_materials = Globals.belt_cluster_iron.get(key, 0)
+    var blueprint_count = Globals.belt_blueprint_counts.get(key, 0)
+    var blueprint_needed = Globals.belt_blueprint_iron_needed.get(key, blueprint_count * 5)
+    var available = mined_materials + cluster_materials
+    var deliverable = min(available, int(float(now - last_time) / transport_time_per_material))
+    var built = min(blueprint_count, deliverable)
+    built = min(built, blueprint_needed)
+    if built > 0:
+        var drone_path := preload("res://assets/drones/space_drone.tscn").resource_path
+        counts[drone_path] = counts.get(drone_path, 0) + built
+        available -= built * 5
+        blueprint_count -= built
+        blueprint_needed -= built * 5
+    Globals.belt_drones[key] = counts
+    Globals.belt_blueprint_counts[key] = blueprint_count
+    Globals.belt_blueprint_iron_needed[key] = blueprint_needed
+    return available


### PR DESCRIPTION
## Summary
- extract belt offline progress logic to new `BeltOfflineProgress` class
- simplify `BeltManager.apply_offline_progress` by delegating to the new class

## Testing
- `gdformat -h` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699812451483238f276502b0057f83