### PR TITLE
Fix planet shader material duplication

### DIFF
--- a/scripts/entities/planet.gd
+++ b/scripts/entities/planet.gd
@@ -6,8 +6,9 @@ extends Node2D
 @export_range(0.0, 1.0) var plants: float = 0.5
 
 func _ready() -> void:
-    var mat = $Sprite2D.material
-    if mat != null:
+    if $Sprite2D.material:
+        $Sprite2D.material = $Sprite2D.material.duplicate()
+        var mat = $Sprite2D.material
         mat.set_shader_parameter("seed", float(seed))
         mat.set_shader_parameter("water", water)
         mat.set_shader_parameter("plants", plants)


### PR DESCRIPTION
## Summary
- avoid planets sharing the same shader material

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686997b72f68832385ca6b1a9ad85e91