### PR TITLE
Add scene path handling for carriers

### DIFF
--- a/scripts/entities/galaxy_drone.gd
+++ b/scripts/entities/galaxy_drone.gd
@@ -5,6 +5,8 @@ extends Node2D
 
 ## Seed of the star this drone currently belongs to.
 @export var belongs_to_star_seed: int = 0
+## Path to the scene that this drone represents when returning to a star system.
+@export var scene_path: String = ""
 
 var target_position: Vector2
 var path_line: Node2D

--- a/scripts/world/globals.gd
+++ b/scripts/world/globals.gd
@@ -16,6 +16,10 @@ const GALAXY_DRONE_SCENE_PATH := "res://assets/drones/galaxy_drone.tscn"
 var entering_drone_count: int = 0
 ## Mapping from star seeds to dictionaries storing drone type counts.
 var star_drone_counts: Dictionary = {}
+## Array of dictionaries describing each carrier drone travelling in the galaxy
+## for every star. Each entry is a list of dictionaries with at least a
+## `scene_path` key used to respawn the carrier when re-entering the star system.
+var star_carrier_info: Dictionary = {}
 ## Positions of asteroids passed to the space scene.
 var space_asteroid_positions: Array = []
 ## Seeds of asteroids passed to the space scene.

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -150,6 +150,19 @@ func _connect_asteroids() -> void:
         if asteroid.has_signal("clicked"):
             asteroid.connect("clicked", Callable(self, "_on_asteroid_clicked").bind(asteroid))
 
+func _record_star_system_drones() -> void:
+    var info: Array = []
+    if drone_manager:
+        for d in drone_manager.get_drones():
+            if "storeable_amount" in d and d.storeable_amount > 0:
+                var path := ""
+                if d.has_meta("scene_path"):
+                    path = str(d.get_meta("scene_path"))
+                elif d.scene_file_path != "":
+                    path = d.scene_file_path
+                info.append({"scene_path": path})
+    Globals.star_carrier_info[Globals.star_seed] = info
+
 
 func _on_asteroid_clicked(click_pos: Vector2, src: Node) -> void:
     Globals.space_origin = click_pos
@@ -180,6 +193,7 @@ func _on_asteroid_clicked(click_pos: Vector2, src: Node) -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
     if event.is_action_pressed('return_to_galaxy') or event.is_action_pressed('toggle_star_system'):
+        _record_star_system_drones()
         var count := 0
         if drone_manager:
             for d in drone_manager.get_drones():
@@ -216,6 +230,7 @@ func _unhandled_input(event: InputEvent) -> void:
                         d.move_to(target)
 
 func _on_back_button_pressed() -> void:
+    _record_star_system_drones()
     var count := 0
     if drone_manager:
         for d in drone_manager.get_drones():

--- a/scripts/world/star_system_drone_manager.gd
+++ b/scripts/world/star_system_drone_manager.gd
@@ -80,15 +80,27 @@ func _spawn_drones() -> void:
         Globals.entering_drone_count = 0
         return
 
+    var info_list: Array = Globals.star_carrier_info.get(Globals.star_seed, [])
     var count := Globals.entering_drone_count
+    if count <= 0:
+        count = info_list.size()
     if count <= 0:
         return
 
     for i in range(count):
-        var d: Node2D = drone_scene.instantiate()
+        var path := drone_scene.resource_path
+        if i < info_list.size():
+            path = info_list[i].get("scene_path", path)
+        var scene := load(path)
+        if scene == null:
+            scene = drone_scene
+            path = drone_scene.resource_path
+        var d: Node2D = scene.instantiate()
         add_child(d)
         d.add_to_group("drone")
-        d.set_meta("scene_path", drone_scene.resource_path)
+        d.set_meta("scene_path", path)
+        if "scene_path" in d:
+            d.scene_path = path
         var planet: Node2D = planets[rng.randi_range(0, planets.size() - 1)]
         d.position = planet.position + Vector2(20, 0).rotated(rng.randf() * TAU)
         drones.append(d)
@@ -99,3 +111,4 @@ func _spawn_drones() -> void:
         add_child(line)
         path_lines.append(line)
     Globals.entering_drone_count = 0
+    Globals.star_carrier_info[Globals.star_seed] = []

--- a/scripts/world/world_generation.gd
+++ b/scripts/world/world_generation.gd
@@ -82,17 +82,28 @@ func _highlight_last_visited() -> void:
 
 func _record_galaxy_drone_counts() -> void:
     var counts: Dictionary = {}
+    var carrier_info: Dictionary = {}
     for d in get_tree().get_nodes_in_group("galaxy_drone"):
         if not ("belongs_to_star_seed" in d):
             continue
         var seed = d.belongs_to_star_seed
         if not counts.has(seed):
             counts[seed] = {}
+            carrier_info[seed] = []
         var type_counts: Dictionary = counts[seed]
         var t := Globals.GALAXY_DRONE_SCENE_PATH
         type_counts[t] = type_counts.get(t, 0) + 1
         counts[seed] = type_counts
+        var path := ""
+        if d.has_meta("scene_path"):
+            path = str(d.get_meta("scene_path"))
+        elif "scene_path" in d:
+            path = d.scene_path
+        elif d.scene_file_path != "":
+            path = d.scene_file_path
+        carrier_info[seed].append({"scene_path": path})
     Globals.star_drone_counts = counts
+    Globals.star_carrier_info = carrier_info
 
 func _spawn_all_drones() -> void:
     if drone_scene == null:
@@ -103,6 +114,7 @@ func _spawn_all_drones() -> void:
         if star == null:
             continue
         var type_counts: Dictionary = Globals.star_drone_counts[seed]
+        var info_list: Array = Globals.star_carrier_info.get(seed, [])
         var count : int = type_counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
         for i in range(count):
             var d: Node2D = drone_scene.instantiate()
@@ -112,6 +124,12 @@ func _spawn_all_drones() -> void:
             d.set("target_position", d.position)
             if "belongs_to_star_seed" in d:
                 d.belongs_to_star_seed = int(seed)
+            var path := drone_scene.resource_path
+            if i < info_list.size():
+                path = info_list[i].get("scene_path", path)
+            d.set_meta("scene_path", path)
+            if "scene_path" in d:
+                d.scene_path = path
 
 func _draw() -> void:
     if selecting:

--- a/scripts/world_generation.gd
+++ b/scripts/world_generation.gd
@@ -71,17 +71,28 @@ func _highlight_last_visited() -> void:
 
 func _record_galaxy_drone_counts() -> void:
     var counts: Dictionary = {}
+    var carrier_info: Dictionary = {}
     for d in get_tree().get_nodes_in_group("galaxy_drone"):
         if not ("belongs_to_star_seed" in d):
             continue
         var seed = d.belongs_to_star_seed
         if not counts.has(seed):
             counts[seed] = {}
+            carrier_info[seed] = []
         var type_counts: Dictionary = counts[seed]
         var t := Globals.GALAXY_DRONE_SCENE_PATH
         type_counts[t] = type_counts.get(t, 0) + 1
         counts[seed] = type_counts
+        var path := ""
+        if d.has_meta("scene_path"):
+            path = str(d.get_meta("scene_path"))
+        elif "scene_path" in d:
+            path = d.scene_path
+        elif d.scene_file_path != "":
+            path = d.scene_file_path
+        carrier_info[seed].append({"scene_path": path})
     Globals.star_drone_counts = counts
+    Globals.star_carrier_info = carrier_info
 
 func _spawn_all_drones() -> void:
     if drone_scene == null:
@@ -92,6 +103,7 @@ func _spawn_all_drones() -> void:
         if star == null:
             continue
         var type_counts: Dictionary = Globals.star_drone_counts[seed]
+        var info_list: Array = Globals.star_carrier_info.get(seed, [])
         var count : int = type_counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
         for i in range(count):
             var d: Node2D = drone_scene.instantiate()
@@ -101,6 +113,12 @@ func _spawn_all_drones() -> void:
             d.set("target_position", d.position)
             if "belongs_to_star_seed" in d:
                 d.belongs_to_star_seed = int(seed)
+            var path := drone_scene.resource_path
+            if i < info_list.size():
+                path = info_list[i].get("scene_path", path)
+            d.set_meta("scene_path", path)
+            if "scene_path" in d:
+                d.scene_path = path
 
 func _center_camera_on_last_visited() -> void:
     var current_scene := get_tree().get_current_scene()


### PR DESCRIPTION
## Summary
- record and respawn galaxy carrier drones with their original scene path
- store carrier info in `Globals.star_carrier_info`
- spawn drones using stored scene paths when entering star systems
- keep scene path metadata on galaxy drones

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a23dde548323a6e037c9b946d5f9