### PR TITLE
Add initial unit tests for galaxy generation and offline mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ progress is calculated exponentially using `scripts/utils/belt_offline_progress.
 Mining therefore slows down as fewer resources remain, preventing the belt from
 being completely emptied while away. The rate of this background mining can be
 tuned via the `offline_progress_factor` property in that script.
+
+## Testing
+
+Unit tests live in the `tests/` directory and can be run with `pytest`.

--- a/tests/test_belt_offline_progress.py
+++ b/tests/test_belt_offline_progress.py
@@ -1,0 +1,61 @@
+import math
+import time
+
+
+def apply_offline_progress_py(
+    key,
+    counts,
+    belt_last_loaded,
+    belt_mining_percent,
+    belt_asteroid_count,
+    belt_total_integrity,
+    now=None,
+    offline_progress_factor=0.05,
+):
+    if now is None:
+        now = int(time.time())
+    last_time = belt_last_loaded.get(key, 0)
+    if last_time == 0:
+        belt_last_loaded[key] = now
+        return 0
+    dt = float(now - last_time)
+    total_asteroids = belt_asteroid_count.get(key, 1)
+    total_integrity = belt_total_integrity.get(key, float(total_asteroids))
+    percent = belt_mining_percent.get(key, 0.0)
+    if not counts:
+        belt_last_loaded[key] = now
+        return 0
+    rate_accum = 0.0
+    for info in counts.values():
+        count = info['count']
+        rate = info['mining_rate']
+        speed = info['move_speed']
+        rate_accum += count * rate * offline_progress_factor / (total_integrity / speed)
+    new_percent = 1.0 - (1.0 - percent) * math.exp(-rate_accum * dt * 0.00001)
+    new_percent = max(0.0, min(1.0, new_percent))
+    belt_mining_percent[key] = new_percent
+    belt_last_loaded[key] = now
+    return new_percent - percent
+
+
+def test_belt_offline_progress_increases_percent():
+    key = 'belt1'
+    now = 2000
+    belt_last_loaded = {key: 1900}
+    belt_mining_percent = {key: 0.0}
+    belt_asteroid_count = {key: 10}
+    belt_total_integrity = {key: 10.0}
+    counts = {
+        'drone.scn': {'count': 1, 'mining_rate': 10.0, 'move_speed': 2.0}
+    }
+    delta = apply_offline_progress_py(
+        key,
+        counts,
+        belt_last_loaded,
+        belt_mining_percent,
+        belt_asteroid_count,
+        belt_total_integrity,
+        now=now,
+    )
+    assert belt_mining_percent[key] > 0.0
+    assert delta > 0.0

--- a/tests/test_galaxy_generator.py
+++ b/tests/test_galaxy_generator.py
@@ -1,0 +1,35 @@
+import math
+import random
+
+
+def generate_star_data_py(star_count, radius, arm_count, twist, arm_spread, random_offset, rng):
+    stars = []
+    for i in range(star_count):
+        t = i / star_count
+        arm = rng.randrange(arm_count)
+        r = t * radius + rng.uniform(-random_offset, random_offset)
+        angle = t * twist + math.tau * arm / arm_count
+        angle += rng.uniform(-arm_spread, arm_spread)
+        x = math.cos(angle) * r
+        y = math.sin(angle) * r
+        stars.append({"position": (x, y), "seed": rng.getrandbits(32)})
+    return stars
+
+
+def test_generate_star_data_radius_and_count():
+    rng = random.Random(123)
+    radius = 10.0
+    star_count = 50
+    data = generate_star_data_py(
+        star_count=star_count,
+        radius=radius,
+        arm_count=3,
+        twist=1.0,
+        arm_spread=0.2,
+        random_offset=0.0,
+        rng=rng,
+    )
+    assert len(data) == star_count
+    # Ensure no star lies beyond the radius
+    max_dist = max(math.hypot(x, y) for x, y in [d["position"] for d in data])
+    assert max_dist <= radius + 1e-6


### PR DESCRIPTION
## Summary
- add basic tests for galaxy generation logic
- add tests for offline mining progress calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5e56ac648323b494a304a67eb76a