### PR TITLE
Refactor drone state management

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 Globals="*res://scripts/world/globals.gd"
+DroneManager="*res://scripts/world/drone_manager.gd"
 
 [input]
 

--- a/scripts/entities/star.gd
+++ b/scripts/entities/star.gd
@@ -14,22 +14,12 @@ var _is_last_visited: bool = false
 ## Handles mouse input on the star. When the player left-clicks the star, the
 ## scene changes to the star system view.
 func _update_star_counts() -> void:
-    var counts: Dictionary = {}
-    for d in get_tree().get_nodes_in_group("galaxy_drone"):
-        if "belongs_to_star_seed" in d:
-            var s = d.belongs_to_star_seed
-            if not counts.has(s):
-                counts[s] = {}
-            var t_counts: Dictionary = counts[s]
-            var t := Globals.GALAXY_DRONE_SCENE_PATH
-            t_counts[t] = t_counts.get(t, 0) + 1
-            counts[s] = t_counts
-    Globals.star_drone_counts = counts
+    DroneManager.record_star_drones(self)
 
 func _on_star_clicked(event: InputEvent) -> void:
     _update_star_counts()
     var drones := get_tree().get_nodes_in_group("galaxy_drone")
-    var counts  = Globals.star_drone_counts.get(seed, {})
+    var counts  = DroneManager.star_drone_counts.get(seed, {})
     var near_count : int = counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
     var first_near_drone: Node2D = null
     for d in drones:

--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -1,7 +1,5 @@
 extends Node
 
-class_name DroneManager
-
 ##
 ## Maintains drone counts and positions between scenes.
 ## Scenes should call the record_* functions when exiting and the

--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -1,0 +1,125 @@
+extends Node
+
+class_name DroneManager
+
+##
+## Maintains drone counts and positions between scenes.
+## Scenes should call the record_* functions when exiting and the
+## spawn_* counterparts when entering so drones persist across
+## galaxy, star system and space scenes.
+##
+
+var system_drone_positions: Array = []
+var star_drone_counts: Dictionary = {}
+var space_drone_positions: Array = []
+
+const PathLine = preload("res://scripts/utils/path_line.gd")
+
+func record_space_drones(space_node: Node2D) -> void:
+    var BeltManager = preload("res://scripts/utils/belt_manager.gd")
+    BeltManager.record_belt_state(space_node, space_node.drone_scene)
+    var positions: Array = []
+    for d in space_node.get_tree().get_nodes_in_group("drone"):
+        positions.append(Globals.space_origin + d.position / 10)
+    system_drone_positions = positions
+
+func spawn_space_drones(space_node: Node2D) -> void:
+    if space_node.drone_scene == null:
+        return
+    var belt_seed := Globals.space_belt_seed
+    var key := str(Globals.star_seed) + "_" + str(belt_seed)
+    var drone_positions := space_drone_positions.duplicate()
+    var counts: Dictionary = Globals.belt_drones.get(key, {})
+    for scene_path in counts.keys():
+        var scene := load(scene_path)
+        if scene == null:
+            continue
+        for i in range(int(counts[scene_path])):
+            var d: Node2D = scene.instantiate()
+            space_node.add_child(d)
+            var pos := Vector2.ZERO
+            if drone_positions.size() > 0:
+                pos = drone_positions.pop_front() * 10
+            d.position = pos
+            d.scale *= 10
+            d.add_to_group("drone")
+            d.set_meta("scene_path", scene_path)
+            if "cluster_scene" in d and "material_cluster_scene" in space_node:
+                d.cluster_scene = space_node.material_cluster_scene
+    for pos in drone_positions:
+        var d: Node2D = space_node.drone_scene.instantiate()
+        space_node.add_child(d)
+        d.position = pos * 10
+        d.scale *= 10
+        d.add_to_group("drone")
+        d.set_meta("scene_path", space_node.drone_scene.resource_path)
+        if "cluster_scene" in d and "material_cluster_scene" in space_node:
+            d.cluster_scene = space_node.material_cluster_scene
+    space_drone_positions = []
+
+func record_star_drones(source: Node) -> void:
+    if source.has_method("get_drones"):
+        var count := 0
+        for d in source.get_drones():
+            count += 1
+        var star_counts: Dictionary = star_drone_counts.get(Globals.star_seed, {})
+        star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
+        star_drone_counts[Globals.star_seed] = star_counts
+        return
+    var counts: Dictionary = {}
+    for d in source.get_tree().get_nodes_in_group("galaxy_drone"):
+        if not ("belongs_to_star_seed" in d):
+            continue
+        var seed = d.belongs_to_star_seed
+        if not counts.has(seed):
+            counts[seed] = {}
+        var type_counts: Dictionary = counts[seed]
+        var t := Globals.GALAXY_DRONE_SCENE_PATH
+        type_counts[t] = type_counts.get(t, 0) + 1
+        counts[seed] = type_counts
+    star_drone_counts = counts
+
+func spawn_star_drones(manager: Node) -> void:
+    if not manager.has_method("drone_scene"):
+        return
+    var drone_scene = manager.drone_scene
+    var planets = manager.planets
+    if drone_scene == null or planets.is_empty():
+        return
+    manager.path_lines.clear()
+    if system_drone_positions.size() > 0:
+        for pos in system_drone_positions:
+            var d: Node2D = drone_scene.instantiate()
+            manager.add_child(d)
+            d.add_to_group("drone")
+            d.set_meta("scene_path", drone_scene.resource_path)
+            d.position = pos
+            manager.drones.append(d)
+            manager.drone_targets.append(d.position)
+            var line: Node2D = PathLine.new()
+            line.set_as_top_level(true)
+            line.visible = false
+            manager.add_child(line)
+            manager.path_lines.append(line)
+        system_drone_positions = []
+        Globals.entering_drone_count = 0
+        return
+    var count := Globals.entering_drone_count
+    if count <= 0:
+        return
+    for i in range(count):
+        var d: Node2D = drone_scene.instantiate()
+        manager.add_child(d)
+        d.add_to_group("drone")
+        d.set_meta("scene_path", drone_scene.resource_path)
+        var planet: Node2D = planets[manager.rng.randi_range(0, planets.size() - 1)]
+        d.position = planet.position + Vector2(20, 0).rotated(manager.rng.randf() * TAU)
+        manager.drones.append(d)
+        manager.drone_targets.append(d.position)
+        var line: Node2D = PathLine.new()
+        line.set_as_top_level(true)
+        line.visible = false
+        manager.add_child(line)
+        manager.path_lines.append(line)
+    Globals.entering_drone_count = 0
+

--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -78,8 +78,6 @@ func record_star_drones(source: Node) -> void:
     star_drone_counts = counts
 
 func spawn_star_drones(manager: Node) -> void:
-    if not manager.has_method("drone_scene"):
-        return
     var drone_scene = manager.drone_scene
     var planets = manager.planets
     if drone_scene == null or planets.is_empty():

--- a/scripts/world/globals.gd
+++ b/scripts/world/globals.gd
@@ -14,22 +14,16 @@ const GALAXY_SCENE_PATH := "res://scenes/galaxy.tscn"
 const GALAXY_DRONE_SCENE_PATH := "res://assets/drones/galaxy_drone.tscn"
 ## Number of drones that should spawn in the next opened star system.
 var entering_drone_count: int = 0
-## Mapping from star seeds to dictionaries storing drone type counts.
-var star_drone_counts: Dictionary = {}
 ## Positions of asteroids passed to the space scene.
 var space_asteroid_positions: Array = []
 ## Seeds of asteroids passed to the space scene.
 var space_asteroid_seeds: Array = []
-## Relative positions of drones passed to the space scene.
-var space_drone_positions: Array = []
 ## Position where the galaxy drone should reappear when returning from a star system.
 var galaxy_drone_position: Vector2 = Vector2.ZERO
 ## Number of drones that should reappear in the galaxy scene.
 var returning_drone_count: int = 0
 ## Star-system coordinates of the asteroid clicked to open the space scene.
 var space_origin: Vector2 = Vector2.ZERO
-## Absolute positions of drones to restore when returning from the space scene.
-var system_drone_positions: Array = []
 ## Path to the space scene file.
 const SPACE_SCENE_PATH := "res://scenes/space.tscn"
 

--- a/scripts/world/space.gd
+++ b/scripts/world/space.gd
@@ -46,34 +46,7 @@ func _ready() -> void:
     Globals.space_asteroid_positions = []
     Globals.space_asteroid_seeds = []
 
-    var drone_positions := Globals.space_drone_positions
-    var counts: Dictionary = Globals.belt_drones.get(key, {})
-    for scene_path in counts.keys():
-        var scene := load(scene_path)
-        if scene == null:
-            continue
-        for i in range(int(counts[scene_path])):
-            var d: Node2D = scene.instantiate()
-            add_child(d)
-            var pos := Vector2.ZERO
-            if drone_positions.size() > 0:
-                pos = drone_positions.pop_front() * 10
-            d.position = pos
-            d.scale *= 10
-            d.add_to_group("drone")
-            d.set_meta("scene_path", scene_path)
-            if "cluster_scene" in d:
-                d.cluster_scene = material_cluster_scene
-    for pos in drone_positions:
-        var d: Node2D = drone_scene.instantiate()
-        add_child(d)
-        d.position = pos * 10
-        d.scale *= 10
-        d.add_to_group("drone")
-        d.set_meta("scene_path", drone_scene.resource_path)
-        if "cluster_scene" in d:
-            d.cluster_scene = material_cluster_scene
-    Globals.space_drone_positions = []
+    DroneManager.spawn_space_drones(self)
 
 
 func _draw() -> void:
@@ -195,8 +168,4 @@ func _on_asteroid_mined(global_pos: Vector2, asteroid: Node) -> void:
     Globals.belt_mining_percent[key] = clamp(mined, 0.0, 1.0)
 
 func _save_system_drone_positions() -> void:
-    BeltManager.record_belt_state(self, drone_scene)
-    var positions: Array = []
-    for d in get_tree().get_nodes_in_group("drone"):
-        positions.append(Globals.space_origin + d.position / 10)
-    Globals.system_drone_positions = positions
+    DroneManager.record_space_drones(self)

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -187,7 +187,7 @@ func _on_asteroid_clicked(click_pos: Vector2, src: Node) -> void:
     for d in drone_manager.get_drones():
         if d.global_position.distance_to(click_pos) <= asteroid_load_radius:
             drone_positions.append(d.global_position - click_pos)
-    Globals.space_drone_positions = drone_positions
+    DroneManager.space_drone_positions = drone_positions
 
     get_tree().change_scene_to_file(Globals.SPACE_SCENE_PATH)
 
@@ -199,9 +199,7 @@ func _unhandled_input(event: InputEvent) -> void:
             for d in drone_manager.get_drones():
                 count += 1
         Globals.returning_drone_count = count
-        var star_counts: Dictionary = Globals.star_drone_counts.get(Globals.star_seed, {})
-        star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
-        Globals.star_drone_counts[Globals.star_seed] = star_counts
+        DroneManager.record_star_drones(drone_manager)
         get_tree().change_scene_to_file(Globals.GALAXY_SCENE_PATH)
     elif event is InputEventMouseButton:
         if event.button_index == MOUSE_BUTTON_LEFT:
@@ -230,16 +228,11 @@ func _unhandled_input(event: InputEvent) -> void:
 
                         
 ## Saves the current number of drones in this star system to
-## `Globals.star_drone_counts` so they can be respawned later.
+## `DroneManager.star_drone_counts` so they can be respawned later.
 func _record_star_system_drones() -> void:
     if drone_manager == null:
         return
-    var count := 0
-    for d in drone_manager.get_drones():
-        count += 1
-    var star_counts: Dictionary = Globals.star_drone_counts.get(Globals.star_seed, {})
-    star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
-    Globals.star_drone_counts[Globals.star_seed] = star_counts
+    DroneManager.record_star_drones(drone_manager)
 
 func _on_back_button_pressed() -> void:
     var count := 0
@@ -248,4 +241,5 @@ func _on_back_button_pressed() -> void:
             if "storeable_amount" in d and d.storeable_amount > 0:
                 count += 1
     Globals.returning_drone_count = count
+    DroneManager.record_star_drones(drone_manager)
     get_tree().change_scene_to_file(Globals.GALAXY_SCENE_PATH)

--- a/scripts/world/star_system_drone_manager.gd
+++ b/scripts/world/star_system_drone_manager.gd
@@ -57,45 +57,4 @@ func _process(delta: float) -> void:
                 line.visible = false
 
 func _spawn_drones() -> void:
-    if drone_scene == null or planets.is_empty():
-        return
-
-    path_lines.clear()
-
-    if Globals.system_drone_positions.size() > 0:
-        for pos in Globals.system_drone_positions:
-            var d: Node2D = drone_scene.instantiate()
-            add_child(d)
-            d.add_to_group("drone")
-            d.set_meta("scene_path", drone_scene.resource_path)
-            d.position = pos
-            drones.append(d)
-            drone_targets.append(d.position)
-            var line: Node2D = PathLine.new()
-            line.set_as_top_level(true)
-            line.visible = false
-            add_child(line)
-            path_lines.append(line)
-        Globals.system_drone_positions = []
-        Globals.entering_drone_count = 0
-        return
-
-    var count := Globals.entering_drone_count
-    if count <= 0:
-        return
-
-    for i in range(count):
-        var d: Node2D = drone_scene.instantiate()
-        add_child(d)
-        d.add_to_group("drone")
-        d.set_meta("scene_path", drone_scene.resource_path)
-        var planet: Node2D = planets[rng.randi_range(0, planets.size() - 1)]
-        d.position = planet.position + Vector2(20, 0).rotated(rng.randf() * TAU)
-        drones.append(d)
-        drone_targets.append(d.position)
-        var line: Node2D = PathLine.new()
-        line.set_as_top_level(true)
-        line.visible = false
-        add_child(line)
-        path_lines.append(line)
-    Globals.entering_drone_count = 0
+    DroneManager.spawn_star_drones(self)

--- a/scripts/world/world_generation.gd
+++ b/scripts/world/world_generation.gd
@@ -84,34 +84,23 @@ func _highlight_last_visited() -> void:
         star.mark_as_last_visited()
 
 ## Records how many drones are currently present in each star.
-## Populates `Globals.star_drone_counts` with a mapping from star seed to a
+## Populates `DroneManager.star_drone_counts` with a mapping from star seed to a
 ## dictionary of drone scene paths and counts.
 func _record_galaxy_drone_counts() -> void:
-    var counts: Dictionary = {}
-    for d in get_tree().get_nodes_in_group("galaxy_drone"):
-        if not ("belongs_to_star_seed" in d):
-            continue
-        var seed = d.belongs_to_star_seed
-        if not counts.has(seed):
-            counts[seed] = {}
-        var type_counts: Dictionary = counts[seed]
-        var t := Globals.GALAXY_DRONE_SCENE_PATH
-        type_counts[t] = type_counts.get(t, 0) + 1
-        counts[seed] = type_counts
-    Globals.star_drone_counts = counts
+    DroneManager.record_star_drones(self)
 
-## Spawns galaxy drones around each star based on `Globals.star_drone_counts`.
+## Spawns galaxy drones around each star based on `DroneManager.star_drone_counts`.
 ## Drones are instantiated from `drone_scene` and given their stored
 ## `belongs_to_star_seed` metadata.
 func _spawn_all_drones() -> void:
     if drone_scene == null:
         return
 
-    for seed in Globals.star_drone_counts.keys():
+    for seed in DroneManager.star_drone_counts.keys():
         var star := _get_star_by_seed(int(seed))
         if star == null:
             continue
-        var type_counts: Dictionary = Globals.star_drone_counts[seed]
+        var type_counts: Dictionary = DroneManager.star_drone_counts[seed]
         var count : int = type_counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
         for i in range(count):
             var d: Node2D = drone_scene.instantiate()
@@ -158,7 +147,7 @@ func _open_last_star_system() -> void:
 ## loading the new scene.
 func _open_star_system(seed_to_open: int) -> void:
     _record_galaxy_drone_counts()
-    var counts = Globals.star_drone_counts.get(seed_to_open, {})
+    var counts = DroneManager.star_drone_counts.get(seed_to_open, {})
     Globals.entering_drone_count = counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
     if Globals.first_load and Globals.entering_drone_count == 0:
         Globals.entering_drone_count = 1

--- a/scripts/world/world_generation.gd
+++ b/scripts/world/world_generation.gd
@@ -149,7 +149,9 @@ func _open_star_system(seed_to_open: int) -> void:
     _record_galaxy_drone_counts()
     var counts = DroneManager.star_drone_counts.get(seed_to_open, {})
     Globals.entering_drone_count = counts.get(Globals.GALAXY_DRONE_SCENE_PATH, 0)
-    if Globals.first_load and Globals.entering_drone_count == 0:
+    if Globals.entering_drone_count == 0 and (
+        Globals.first_load or DroneManager.star_drone_counts.is_empty()
+    ):
         Globals.entering_drone_count = 1
     Globals.star_seed = seed_to_open
     Globals.start_star_seed = seed_to_open


### PR DESCRIPTION
## Summary
- add a `DroneManager` autoload to track drone positions and counts
- use new manager when spawning and recording drones across scenes
- remove old global arrays from `Globals`
- wire scenes to call `DroneManager` helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a6e29086c8323adcbf0b3660649d9