### PR TITLE
Fix galaxy drone star assignment

### DIFF
--- a/scripts/entities/star.gd
+++ b/scripts/entities/star.gd
@@ -34,11 +34,16 @@ func _on_star_clicked(event: InputEvent) -> void:
         Globals.start_star_seed = seed
         get_tree().change_scene_to_file(Globals.STAR_SYSTEM_SCENE_PATH)
     elif event.button_index == MOUSE_BUTTON_RIGHT and drones.size() > 0:
-        var d := drones[0]
-        if d.has_method("move_to"):
-            d.call("move_to", global_position)
-            if "belongs_to_star_seed" in d:
-                d.belongs_to_star_seed = seed
+        var parent := get_parent()
+        if parent != null and parent.has_method("send_selected_drones_to_star"):
+            parent.send_selected_drones_to_star(global_position, seed)
+            _update_star_counts()
+        else:
+            var d := drones[0]
+            if d.has_method("move_to"):
+                d.call("move_to", global_position)
+                if "belongs_to_star_seed" in d:
+                    d.belongs_to_star_seed = seed
 
 func _handle_click_event(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.pressed:

--- a/scripts/world/world_generation.gd
+++ b/scripts/world/world_generation.gd
@@ -111,6 +111,15 @@ func _spawn_all_drones() -> void:
             if "belongs_to_star_seed" in d:
                 d.belongs_to_star_seed = int(seed)
 
+func send_selected_drones_to_star(target: Vector2, star_seed_value: int) -> void:
+    if selected_drones.is_empty():
+        return
+    for d in selected_drones:
+        if d.has_method("move_to"):
+            d.move_to(target)
+        if "belongs_to_star_seed" in d:
+            d.belongs_to_star_seed = star_seed_value
+
 func _draw() -> void:
     if selecting:
         var rect := Rect2(to_local(select_start), select_rect.size)


### PR DESCRIPTION
## Summary
- allow galaxy stars to send all selected drones
- track star assignment for each selected drone

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a7be428c483239f0e28fc6fbb8c8b