### PR TITLE
Limit system drone spawns to carriers

### DIFF
--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -18,7 +18,8 @@ func record_space_drones(space_node: Node2D) -> void:
     BeltManager.record_belt_state(space_node, space_node.drone_scene)
     var positions: Array = []
     for d in space_node.get_tree().get_nodes_in_group("drone"):
-        positions.append(Globals.space_origin + d.position / 10)
+        if "storage_capacity" in d and d.storage_capacity > 0.0:
+            positions.append(Globals.space_origin + d.position / 10)
     system_drone_positions = positions
 
 func spawn_space_drones(space_node: Node2D) -> void:
@@ -59,7 +60,8 @@ func record_star_drones(source: Node) -> void:
     if source.has_method("get_drones"):
         var count := 0
         for d in source.get_drones():
-            count += 1
+            if "storage_capacity" in d and d.storage_capacity > 0.0:
+                count += 1
         var star_counts: Dictionary = star_drone_counts.get(Globals.star_seed, {})
         star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
         star_drone_counts[Globals.star_seed] = star_counts

--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -7,7 +7,7 @@ extends Node
 ## galaxy, star system and space scenes.
 ##
 
-var system_drone_positions: Array = []
+var system_drone_data: Array = []
 var star_drone_counts: Dictionary = {}
 var space_drone_positions: Array = []
 
@@ -16,11 +16,15 @@ const PathLine = preload("res://scripts/utils/path_line.gd")
 func record_space_drones(space_node: Node2D) -> void:
     var BeltManager = preload("res://scripts/utils/belt_manager.gd")
     BeltManager.record_belt_state(space_node, space_node.drone_scene)
-    var positions: Array = []
+    var data: Array = []
     for d in space_node.get_tree().get_nodes_in_group("drone"):
         if "storage_capacity" in d and d.storage_capacity > 0.0:
-            positions.append(Globals.space_origin + d.position / 10)
-    system_drone_positions = positions
+            var entry := {
+                "pos": Globals.space_origin + d.position / 10,
+                "path": d.get_meta("scene_path", space_node.drone_scene.resource_path)
+            }
+            data.append(entry)
+    system_drone_data = data
 
 func spawn_space_drones(space_node: Node2D) -> void:
     if space_node.drone_scene == null:
@@ -85,13 +89,17 @@ func spawn_star_drones(manager: Node) -> void:
     if drone_scene == null or planets.is_empty():
         return
     manager.path_lines.clear()
-    if system_drone_positions.size() > 0:
-        for pos in system_drone_positions:
-            var d: Node2D = drone_scene.instantiate()
+    if system_drone_data.size() > 0:
+        for info in system_drone_data:
+            var path := info.get("path", drone_scene.resource_path)
+            var scene := load(path)
+            if scene == null:
+                continue
+            var d: Node2D = scene.instantiate()
             manager.add_child(d)
             d.add_to_group("drone")
-            d.set_meta("scene_path", drone_scene.resource_path)
-            d.position = pos
+            d.set_meta("scene_path", path)
+            d.position = info.get("pos", Vector2.ZERO)
             manager.drones.append(d)
             manager.drone_targets.append(d.position)
             var line: Node2D = PathLine.new()
@@ -99,7 +107,7 @@ func spawn_star_drones(manager: Node) -> void:
             line.visible = false
             manager.add_child(line)
             manager.path_lines.append(line)
-        system_drone_positions = []
+        system_drone_data = []
         Globals.entering_drone_count = 0
         return
     var count := Globals.entering_drone_count

--- a/scripts/world/drone_manager.gd
+++ b/scripts/world/drone_manager.gd
@@ -21,7 +21,7 @@ func record_space_drones(space_node: Node2D) -> void:
         if "storage_capacity" in d and d.storage_capacity > 0.0:
             var entry := {
                 "pos": Globals.space_origin + d.position / 10,
-                "path": d.get_meta("scene_path", space_node.drone_scene.resource_path)
+                "storage": float(d.storage_capacity)
             }
             data.append(entry)
     system_drone_data = data
@@ -64,7 +64,12 @@ func record_star_drones(source: Node) -> void:
     if source.has_method("get_drones"):
         var count := 0
         for d in source.get_drones():
-            if "storage_capacity" in d and d.storage_capacity > 0.0:
+            var cap := 0.0
+            if "storage_capacity" in d:
+                cap = float(d.storage_capacity)
+            elif d.has_meta("storage_capacity"):
+                cap = float(d.get_meta("storage_capacity"))
+            if cap > 0.0:
                 count += 1
         var star_counts: Dictionary = star_drone_counts.get(Globals.star_seed, {})
         star_counts[Globals.GALAXY_DRONE_SCENE_PATH] = count
@@ -91,14 +96,11 @@ func spawn_star_drones(manager: Node) -> void:
     manager.path_lines.clear()
     if system_drone_data.size() > 0:
         for info in system_drone_data:
-            var path := info.get("path", drone_scene.resource_path)
-            var scene := load(path)
-            if scene == null:
-                continue
-            var d: Node2D = scene.instantiate()
+            var d: Node2D = drone_scene.instantiate()
             manager.add_child(d)
             d.add_to_group("drone")
-            d.set_meta("scene_path", path)
+            d.set_meta("scene_path", drone_scene.resource_path)
+            d.set_meta("storage_capacity", info.get("storage", 0.0))
             d.position = info.get("pos", Vector2.ZERO)
             manager.drones.append(d)
             manager.drone_targets.append(d.position)

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -197,7 +197,8 @@ func _unhandled_input(event: InputEvent) -> void:
         var count := 0
         if drone_manager:
             for d in drone_manager.get_drones():
-                count += 1
+                if "storage_capacity" in d and d.storage_capacity > 0.0:
+                    count += 1
         Globals.returning_drone_count = count
         DroneManager.record_star_drones(drone_manager)
         get_tree().change_scene_to_file(Globals.GALAXY_SCENE_PATH)
@@ -238,7 +239,7 @@ func _on_back_button_pressed() -> void:
     var count := 0
     if drone_manager:
         for d in drone_manager.get_drones():
-            if "storeable_amount" in d and d.storeable_amount > 0:
+            if "storage_capacity" in d and d.storage_capacity > 0.0:
                 count += 1
     Globals.returning_drone_count = count
     DroneManager.record_star_drones(drone_manager)

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -197,7 +197,12 @@ func _unhandled_input(event: InputEvent) -> void:
         var count := 0
         if drone_manager:
             for d in drone_manager.get_drones():
-                if "storage_capacity" in d and d.storage_capacity > 0.0:
+                var cap := 0.0
+                if "storage_capacity" in d:
+                    cap = float(d.storage_capacity)
+                elif d.has_meta("storage_capacity"):
+                    cap = float(d.get_meta("storage_capacity"))
+                if cap > 0.0:
                     count += 1
         Globals.returning_drone_count = count
         DroneManager.record_star_drones(drone_manager)
@@ -239,7 +244,12 @@ func _on_back_button_pressed() -> void:
     var count := 0
     if drone_manager:
         for d in drone_manager.get_drones():
-            if "storage_capacity" in d and d.storage_capacity > 0.0:
+            var cap := 0.0
+            if "storage_capacity" in d:
+                cap = float(d.storage_capacity)
+            elif d.has_meta("storage_capacity"):
+                cap = float(d.get_meta("storage_capacity"))
+            if cap > 0.0:
                 count += 1
     Globals.returning_drone_count = count
     DroneManager.record_star_drones(drone_manager)


### PR DESCRIPTION
## Summary
- spawn system drones only for drones with `storage_capacity` > 0
- record only carrier drones when leaving space or a system

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a83bb57c48323b32d1823456402fc