### PR TITLE
Enhance planet and moon appearance

### DIFF
--- a/assets/celestials/planet.tscn
+++ b/assets/celestials/planet.tscn
@@ -17,6 +17,7 @@ scale = Vector2(10, 10)
 script = ExtResource("1")
 water = 0.21
 plants = 0.823
+grid_size = 20.0
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_planet")

--- a/assets/shaders/planet.gdshader
+++ b/assets/shaders/planet.gdshader
@@ -5,6 +5,23 @@ uniform float water = 0.5;
 uniform float plants = 0.5;
 uniform float grid_size = 10.0;
 
+float rand(vec2 p) {
+    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    float a = rand(i + seed);
+    float b = rand(i + vec2(1.0, 0.0) + seed);
+    float c = rand(i + vec2(0.0, 1.0) + seed);
+    float d = rand(i + vec2(1.0, 1.0) + seed);
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(a, b, u.x) +
+           (c - a) * u.y * (1.0 - u.x) +
+           (d - b) * u.x * u.y;
+}
+
 vec3 get_land_color() {
     float r = max(0.0, 1.0 - water - plants);
     float g = plants;
@@ -17,9 +34,10 @@ vec3 get_water_color() {
 }
 
 void fragment() {
-    vec2 cell = floor(UV * grid_size);
-    float rnd = fract(sin(dot(cell + seed, vec2(12.9898, 78.233))) * 43758.5453);
-    vec3 color = (rnd < water) ? get_water_color() : get_land_color();
+    float n = noise(UV * grid_size);
+    vec3 land = get_land_color();
+    vec3 water_col = get_water_color();
+    vec3 color = mix(land, water_col, smoothstep(water - 0.1, water + 0.1, n));
 
     float radius = 0.5;
     float mask = step(distance(UV, vec2(0.5)), radius);

--- a/scripts/entities/planet.gd
+++ b/scripts/entities/planet.gd
@@ -4,6 +4,7 @@ extends Node2D
 @export var seed: int = 0
 @export_range(0.0, 1.0) var water: float = 0.5
 @export_range(0.0, 1.0) var plants: float = 0.5
+@export_range(5.0, 40.0) var grid_size: float = 20.0
 
 func _ready() -> void:
     if $Sprite2D.material:
@@ -12,6 +13,7 @@ func _ready() -> void:
         mat.set_shader_parameter("seed", float(seed))
         mat.set_shader_parameter("water", water)
         mat.set_shader_parameter("plants", plants)
+        mat.set_shader_parameter("grid_size", grid_size)
 
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:

--- a/scripts/world/star_system.gd
+++ b/scripts/world/star_system.gd
@@ -98,6 +98,8 @@ func _spawn_planets(sun: Node2D) -> void:
             body.water = rng.randf()
         if "plants" in body:
             body.plants = rng.randf()
+        if "grid_size" in body:
+            body.grid_size = rng.randf_range(10.0, 30.0)
         if is_belt:
             if "radius" in body:
                 body.radius = offset.length()
@@ -125,9 +127,11 @@ func _spawn_moons(planet: Node2D) -> void:
         if "seed" in moon:
             moon.seed = rng.randi()
         if "water" in moon:
-            moon.water = rng.randf()
+            moon.water = rng.randf_range(0.0, 0.3)
         if "plants" in moon:
-            moon.plants = rng.randf()
+            moon.plants = rng.randf_range(0.0, 0.2)
+        if "grid_size" in moon:
+            moon.grid_size = rng.randf_range(5.0, 15.0)
         add_child(moon)
         planets.append(moon)
         moon_orbits.append({"center": planet.position, "radius": radius})


### PR DESCRIPTION
## Summary
- create per-pixel noise in `planet.gdshader` for smoother terrain
- allow planets to set `grid_size` from script
- randomize grid size and barren features for moons
- tweak planet scene to expose grid size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8f842a80832397b19512bdd7d184